### PR TITLE
[views] editor: references rename 'text' to 'citation'.

### DIFF
--- a/app/views/submission.scala.html
+++ b/app/views/submission.scala.html
@@ -403,7 +403,7 @@
                                             <span class="drag-handle-icon glyphicon glyphicon-align-justify"></span>
                                         </td>
                                         <td>
-                                            <input type="text" class="form-control input-sm" placeholder="Text"
+                                            <input type="text" class="form-control input-sm" placeholder="Citation"
                                                    maxlength="200" data-bind="value: reference.text" />
                                         </td>
                                         <td>


### PR DESCRIPTION
Fixes issue #177
