### PR TITLE
[view] dash.admin: compact list to get a better overview

### DIFF
--- a/app/assets/stylesheets/layout.less
+++ b/app/assets/stylesheets/layout.less
@@ -368,3 +368,7 @@ body {
 .admin-form {
   max-width: 600px;
 }
+
+.table-condensed {
+  font-size: 13px;
+}

--- a/app/views/dashboard/admin/abstracts.scala.html
+++ b/app/views/dashboard/admin/abstracts.scala.html
@@ -28,7 +28,7 @@
         </div>
 
         <!-- The abstract list -->
-        <table class="table .table-condensed">
+        <table class="table table-condensed">
             <thead>
                 <tr>
                     <th>Authors</th>
@@ -40,7 +40,7 @@
             <tbody data-bind="foreach: abstracts">
                 <tr>
                     <td><span data-bind="text: $root.mkAuthorList($data)"></span></td>
-                    <td><b><span data-bind="text: title"> </span></b></td>
+                    <td><span data-bind="text: title"> </span></td>
                     <td>
                         <div class="dropdown">
                             <button id="statemenu" type="button" class="btn btn-xs btn-default dropdown-toggle"


### PR DESCRIPTION
Actually use table-condensed css style. Make the font size for
those tables 13px and remove the bold from the font-weight.
