### PR TITLE
Unified exception handling in Global

### DIFF
--- a/app/Global.scala
+++ b/app/Global.scala
@@ -1,10 +1,42 @@
+import javax.persistence.{EntityNotFoundException, NoResultException}
+
 import play.api._
-import play.api.mvc._
+import play.api.libs.json.{JsError, JsResultException, Json}
 import play.api.mvc.Results._
+import play.api.mvc._
+
 import scala.concurrent.Future
 
 object Global extends GlobalSettings {
+
   override def onHandlerNotFound(request: RequestHeader) = {
     Future.successful(NotFound(views.html.error.NotFound()))
+  }
+
+  override def onError(request: RequestHeader, ex: Throwable): Future[SimpleResult] = {
+    Future {
+      if (acceptsJson(request))
+        exHandlerJSON(ex)
+      else
+        exHandlerHTML(ex)
+    }
+  }
+
+  def acceptsJson(request: RequestHeader) : Boolean = {
+    request.accepts("application/json") || request.accepts("text/json")
+  }
+
+  def exHandlerHTML(e: Throwable) : SimpleResult = {
+    case e: NoResultException => NotFound(views.html.error.NotFound())
+    case e: Exception => InternalServerError(views.html.error.InternalServerError(e))
+  }
+
+  def exHandlerJSON(e: Throwable) : SimpleResult = {
+    case e: NoResultException => NotFound(Json.obj("error" -> true, e.getMessage -> e.getStackTraceString))
+    case e: EntityNotFoundException => NotFound(Json.obj("error" -> true, e.getMessage -> e.getStackTraceString))
+    case e: IllegalArgumentException => BadRequest(Json.obj("error" -> true, e.getMessage -> e.getStackTraceString))
+    case e: JsResultException => BadRequest(Json.obj("error" -> true, "causes" -> JsError.toFlatJson(e.errors)))
+    case e: IllegalAccessException => Forbidden(Json.obj("error" -> true, e.getMessage -> e.getStackTraceString))
+    case e: Exception => InternalServerError(Json.obj("error" -> true, e.getMessage -> e.getStackTraceString))
   }
 }

--- a/app/Global.scala
+++ b/app/Global.scala
@@ -14,7 +14,7 @@ object Global extends GlobalSettings {
   }
 
   override def onError(request: RequestHeader, ex: Throwable): Future[SimpleResult] = {
-    Future {
+    Future.successful {
       if (acceptsJson(request))
         exHandlerJSON(ex)
       else
@@ -27,16 +27,20 @@ object Global extends GlobalSettings {
   }
 
   def exHandlerHTML(e: Throwable) : SimpleResult = {
-    case e: NoResultException => NotFound(views.html.error.NotFound())
-    case e: Exception => InternalServerError(views.html.error.InternalServerError(e))
+    e match {
+      case e: NoResultException => NotFound(views.html.error.NotFound())
+      case e: Exception => InternalServerError(views.html.error.InternalServerError(e))
+    }
   }
 
   def exHandlerJSON(e: Throwable) : SimpleResult = {
-    case e: NoResultException => NotFound(Json.obj("error" -> true, e.getMessage -> e.getStackTraceString))
-    case e: EntityNotFoundException => NotFound(Json.obj("error" -> true, e.getMessage -> e.getStackTraceString))
-    case e: IllegalArgumentException => BadRequest(Json.obj("error" -> true, e.getMessage -> e.getStackTraceString))
-    case e: JsResultException => BadRequest(Json.obj("error" -> true, "causes" -> JsError.toFlatJson(e.errors)))
-    case e: IllegalAccessException => Forbidden(Json.obj("error" -> true, e.getMessage -> e.getStackTraceString))
-    case e: Exception => InternalServerError(Json.obj("error" -> true, e.getMessage -> e.getStackTraceString))
+    e match {
+      case e: NoResultException => NotFound(Json.obj("error" -> true, e.getMessage -> e.getStackTraceString))
+      case e: EntityNotFoundException => NotFound(Json.obj("error" -> true, e.getMessage -> e.getStackTraceString))
+      case e: IllegalArgumentException => BadRequest(Json.obj("error" -> true, e.getMessage -> e.getStackTraceString))
+      case e: JsResultException => BadRequest(Json.obj("error" -> true, "causes" -> JsError.toFlatJson(e.errors)))
+      case e: IllegalAccessException => Forbidden(Json.obj("error" -> true, e.getMessage -> e.getStackTraceString))
+      case e: Exception => InternalServerError(Json.obj("error" -> true, e.getMessage -> e.getStackTraceString))
+    }
   }
 }

--- a/app/conf/Global.scala
+++ b/app/conf/Global.scala
@@ -1,3 +1,5 @@
+package conf
+
 import javax.persistence.{EntityNotFoundException, NoResultException}
 
 import play.api._

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -16,7 +16,7 @@ application.langs="en"
 # ~~~~~
 # Define the Global object class for this application.
 # Default to Global in the root package.
-# application.global=Global
+application.global=conf.Global
 
 # Router
 # ~~~~~

--- a/test/TestAll.scala
+++ b/test/TestAll.scala
@@ -10,7 +10,7 @@
 import org.scalatest.Suites
 import service.{FigureServiceTest, UserStoreTest, ConferenceServiceTest, AbstractServiceTest}
 import util.serializer.SerializerTest
-import controller.{AbstractsCtrlTest, ConferenceCtrlTest}
+import controller.{FigureCtrlTest, AbstractsCtrlTest, ConferenceCtrlTest}
 
 
 /**
@@ -24,6 +24,7 @@ class TestAll extends Suites(
   new FigureServiceTest,
   new UserStoreTest,
   new ConferenceCtrlTest,
-  new AbstractsCtrlTest
+  new AbstractsCtrlTest,
+  new FigureCtrlTest
 
 )

--- a/test/controller/AbstractsCtrlTest.scala
+++ b/test/controller/AbstractsCtrlTest.scala
@@ -29,7 +29,7 @@ class AbstractsCtrlTest extends BaseCtrlTest {
     var id = "NOTEXISTANT"
     var req = FakeRequest(GET, s"/api/abstracts/$id")
 
-    var result = route(AbstractsCtrlTest.app, req).get
+    var result = routeWithErrors(AbstractsCtrlTest.app, req).get
     assert(status(result) == NOT_FOUND)
 
     id = assets.abstracts(0).uuid //is published
@@ -56,7 +56,7 @@ class AbstractsCtrlTest extends BaseCtrlTest {
     val confId = assets.conferences(0).uuid
     val reqNoAuth = FakeRequest(POST, s"/api/conferences/$confId/abstracts").withJsonBody(body)
 
-    val reqNoAuthResult = route(AbstractsCtrlTest.app, reqNoAuth).get
+    val reqNoAuthResult = routeWithErrors(AbstractsCtrlTest.app, reqNoAuth).get
     assert(status(reqNoAuthResult) == UNAUTHORIZED)
 
     val reqAuth = reqNoAuth.withCookies(cookie)
@@ -72,7 +72,7 @@ class AbstractsCtrlTest extends BaseCtrlTest {
     val bobCookie =  getCookie(assets.bob.identityId, "testtest")
     val confIdClosed = assets.conferences(1).uuid
     val rq = FakeRequest(POST, s"/api/conferences/$confIdClosed/abstracts").withJsonBody(body).withCookies(bobCookie)
-    val rqResult = route(AbstractsCtrlTest.app, rq).get
+    val rqResult = routeWithErrors(AbstractsCtrlTest.app, rq).get
     assert(status(rqResult) == FORBIDDEN)
   }
 
@@ -186,7 +186,7 @@ class AbstractsCtrlTest extends BaseCtrlTest {
     assert(status(response) == OK)
 
     postR = FakeRequest(PUT, s"/api/abstracts/$abstrid/owners").withCookies(adminCookie).withJsonBody(body)
-    response = route(AbstractsCtrlTest.app, postR).get
+    response = routeWithErrors(AbstractsCtrlTest.app, postR).get
 
     assert(status(response) == FORBIDDEN)
   }
@@ -201,7 +201,7 @@ class AbstractsCtrlTest extends BaseCtrlTest {
     var stateChange = Json.obj("state" -> "Submitted", "note" -> "")
     val reqNoAuth = FakeRequest(PUT, s"/api/abstracts/$absUUID/state").withJsonBody(stateChange)
 
-    val reqNoAuthResult = route(AbstractsCtrlTest.app, reqNoAuth).get
+    val reqNoAuthResult = routeWithErrors(AbstractsCtrlTest.app, reqNoAuth).get
     assert(status(reqNoAuthResult) == UNAUTHORIZED)
 
     //try as bob, who is one of the owners, so should be OK
@@ -214,7 +214,7 @@ class AbstractsCtrlTest extends BaseCtrlTest {
     //try to change a state that we are not allowed to as owner
     stateChange = Json.obj("state" -> "InReview", "note" -> "")
     reqAuth = reqAuth.withJsonBody(stateChange)
-    reqAuthResult = route(AbstractsCtrlTest.app, reqAuth).get
+    reqAuthResult = routeWithErrors(AbstractsCtrlTest.app, reqAuth).get
 
     assert(status(reqAuthResult) == FORBIDDEN)
 
@@ -232,13 +232,13 @@ class AbstractsCtrlTest extends BaseCtrlTest {
     val absUUID = abstr.uuid
     val reqNoAuth = FakeRequest("PATCH", s"/api/abstracts/$absUUID").withJsonBody(patch)
 
-    val reqNoAuthResult = route(AbstractsCtrlTest.app, reqNoAuth).get
+    val reqNoAuthResult = routeWithErrors(AbstractsCtrlTest.app, reqNoAuth).get
     assert(status(reqNoAuthResult) == UNAUTHORIZED)
 
     //bob should not be allowed to do this
     val bobCookie = getCookie(assets.bob.identityId, "testtest")
     var reqAuth = reqNoAuth.withCookies(bobCookie)
-    var reqAuthResult = route(AbstractsCtrlTest.app, reqAuth).get
+    var reqAuthResult = routeWithErrors(AbstractsCtrlTest.app, reqAuth).get
     assert(status(reqAuthResult) == FORBIDDEN)
 
     //now try as alice (who is conference admin)

--- a/test/controller/BaseCtrlTest.scala
+++ b/test/controller/BaseCtrlTest.scala
@@ -1,12 +1,20 @@
 package controller
 
+import conf.Global
 import org.junit.Before
 import org.scalatest.junit.JUnitSuite
-import play.api.test.FakeRequest
+import play.api.Application
+import play.api.http.Writeable
+import play.api.mvc.{Request, SimpleResult}
 import play.api.test.Helpers._
+import play.api.test._
 import securesocial.controllers.ProviderController.authenticateByPost
 import securesocial.core.IdentityId
 import service.Assets
+import scala.concurrent.{ExecutionContext, Future}
+import ExecutionContext.Implicits._
+
+import scala.concurrent.Future
 
 
 trait BaseCtrlTest extends JUnitSuite {
@@ -24,6 +32,17 @@ trait BaseCtrlTest extends JUnitSuite {
     val authResponse = authenticateByPost(id.providerId)(authRequest)
     cookies(authResponse).get("id").getOrElse {
       throw new RuntimeException("Could not authenticate successfully")
+    }
+  }
+
+  /**
+   * Call route and handle errors with Global.onError().
+   */
+  def routeWithErrors[T](app: Application, req: Request[T])(implicit w: Writeable[T]): Option[Future[SimpleResult]] = {
+    route(req).map { result =>
+      result.recoverWith {
+        case t: Throwable => Global.onError(req, t)
+      }
     }
   }
 

--- a/test/controller/ConferenceCtrlTest.scala
+++ b/test/controller/ConferenceCtrlTest.scala
@@ -1,18 +1,13 @@
 package controller
 
-import scala.concurrent.Future
 import org.junit._
-import play.api.test._
 import play.api.Play
-import play.api.test.Helpers._
-
-import utils.serializer.{AccountFormat, ConferenceFormat}
-import play.api.libs.json.{JsValue, JsArray, JsObject}
-import utils.DefaultRoutesResolver._
-import scala.Some
-import play.api.test.FakeApplication
+import play.api.libs.json.{JsArray, JsObject, JsValue}
 import play.api.mvc.Cookie
-import play.mvc.SimpleResult
+import play.api.test.Helpers._
+import play.api.test._
+import utils.DefaultRoutesResolver._
+import utils.serializer.{AccountFormat, ConferenceFormat}
 
 
 /**
@@ -82,7 +77,7 @@ class ConferenceCtrlTest extends BaseCtrlTest {
 
     val bobCookie = getCookie(assets.bob.identityId, "testtest")
     val updateUnauth = updateAuth.withCookies(bobCookie)
-    val failed = route(ConferenceCtrlTest.app, updateUnauth).get
+    val failed = routeWithErrors(ConferenceCtrlTest.app, updateUnauth).get
     assert(status(failed) == FORBIDDEN)
   }
 
@@ -95,7 +90,7 @@ class ConferenceCtrlTest extends BaseCtrlTest {
 
     val id = "NOTEXISTANT"
     val bad = FakeRequest(DELETE, s"/api/conferences/$id").withCookies(cookie)
-    val failed = route(ConferenceCtrlTest.app, bad).get
+    val failed = routeWithErrors(ConferenceCtrlTest.app, bad).get
     assert(status(failed) == NOT_FOUND)
   }
 
@@ -138,7 +133,7 @@ class ConferenceCtrlTest extends BaseCtrlTest {
     assert(status(response) == OK)
 
     postR = FakeRequest(PUT, s"/api/conferences/$confid/owners").withCookies(adminCookie).withJsonBody(body)
-    response = route(ConferenceCtrlTest.app, postR).get
+    response = routeWithErrors(ConferenceCtrlTest.app, postR).get
 
     assert(status(response) == FORBIDDEN)
   }

--- a/test/controller/FigureCtrlTest.scala
+++ b/test/controller/FigureCtrlTest.scala
@@ -129,7 +129,7 @@ class FigureCtrlTest extends BaseCtrlTest {
 
     val id = "NOTEXISTANT"
     val bad = FakeRequest(DELETE, s"/api/figures/$id").withCookies(cookie)
-    val failed = route(FigureCtrlTest.app, bad).get
+    val failed = routeWithErrors(FigureCtrlTest.app, bad).get
     assert(status(failed) == NOT_FOUND)
   }
 }


### PR DESCRIPTION
Handle all errors inside the `conf.Global` object.

This solves #229 