### PR TITLE
Use web-jars for client side dependencies

### DIFF
--- a/app/views/template.scala.html
+++ b/app/views/template.scala.html
@@ -25,16 +25,16 @@
     <script type="text/javascript" src="@routes.Assets.at("javascripts/browser.js")"></script>
 
     <!-- jquery .min.js for optimized version-->
-    <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/jquery/1.11.0/jquery.js"></script>
-    <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/jqueryui/1.10.4/jquery-ui.min.js"></script>
+    <script type="text/javascript" src="@routes.Assets.at("lib/jquery/jquery.min.js")"></script>
+    <script type="text/javascript" src="@routes.Assets.at("lib/jquery-ui/jquery-ui.min.js")"></script>
     <!-- bootstrap .min.js or min.css for optimized version -->
-    <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.1.1/js/bootstrap.js"></script>
+    <script type="text/javascript" src="@routes.Assets.at("lib/bootstrap/js/bootstrap.min.js")"></script>
     <link rel="stylesheet" href="@routes.Assets.at("stylesheets/bootstrap.min.css")" />
 
     <!-- knockout s/-debug/-min/ for optimized version -->
-    <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/knockout/3.0.0/knockout-debug.js"></script>
+    <script type="text/javascript" src="@routes.Assets.at("lib/knockout/knockout.js")"></script>
     <script type="text/javascript" src="@routes.Assets.at("javascripts/knockout-sortable.min.js")"></script>
-    <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/sammy.js/0.7.4/sammy.min.js"></script>
+    <script type="text/javascript" src="@routes.Assets.at("lib/sammy/sammy.min.js")"></script>
 
     <!-- project fonts -->
     <link href='//fonts.googleapis.com/css?family=EB+Garamond|Open+Sans' rel='stylesheet' type='text/css'>

--- a/build.sbt
+++ b/build.sbt
@@ -30,5 +30,3 @@ libraryDependencies ++= Seq(
 includeFilter in (Assets, LessKeys.less) := "*.less"
 
 excludeFilter in (Assets, LessKeys.less) := "_*.less"
-
-pipelineStages := Seq(rjs, digest)

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,4 @@
+
 name := "GCA-Web"
 
 version := "1.0"
@@ -15,9 +16,19 @@ libraryDependencies ++= Seq(
   "org.eclipse.persistence" % "org.eclipse.persistence.jpa" % "2.5.2",
   "com.typesafe.play.plugins" %% "play-plugins-mailer" % "2.3.0",
   "com.mohiva" %% "play-silhouette" % "1.0",
-  "org.postgresql" % "postgresql" % "9.3-1100-jdbc4"
+  "org.postgresql" % "postgresql" % "9.3-1100-jdbc4",
+  // web jars
+  "org.webjars" % "requirejs" % "2.1.15",
+  "org.webjars" % "jquery" % "1.11.2",
+  "org.webjars" % "jquery-ui" % "1.11.2",
+  "org.webjars" % "bootstrap" % "3.3.1" exclude("org.webjars", "jquery"),
+  "org.webjars" % "knockout" % "3.2.0" exclude("org.webjars", "jquery"),
+  "org.webjars" % "sammy" % "0.7.4",
+  "org.webjars" % "momentjs" % "2.9.0"
 )
 
 includeFilter in (Assets, LessKeys.less) := "*.less"
 
 excludeFilter in (Assets, LessKeys.less) := "_*.less"
+
+pipelineStages := Seq(rjs, digest)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,4 +7,13 @@ resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/release
 // The Play plugin
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.3.7")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-less" % "1.0.0")
+// SBT web plugins
+addSbtPlugin("com.typesafe.sbt" % "sbt-less" % "1.0.4")
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-jshint" % "1.0.2")
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-rjs" % "1.0.7")
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.0")
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-gzip" % "1.0.0")

--- a/public/javascripts/lib/astate.js
+++ b/public/javascripts/lib/astate.js
@@ -1,7 +1,7 @@
 require.config({
     baseUrl: '/assets/javascripts/',
     paths: {
-        'moment': ['//cdnjs.cloudflare.com/ajax/libs/moment.js/2.5.1/moment.min']
+        'moment': ['/assets/lib/momentjs/min/moment.min']
     },
     noGlobal: true
 });

--- a/public/javascripts/lib/models.js
+++ b/public/javascripts/lib/models.js
@@ -1,7 +1,7 @@
 require.config({
     baseUrl: '/assets/javascripts/',
     paths: {
-        'moment': ['//cdnjs.cloudflare.com/ajax/libs/moment.js/2.5.1/moment.min']
+        'moment': ['/assets/lib/momentjs/min/moment.min']
     },
     noGlobal: true
 });


### PR DESCRIPTION
Dependencies are now handled vie web-jars. Except `mathjax` which is not in the repo.

This should fix #223

The next step is now to make them available via require js (#225)