### PR TITLE
Editor check admin

### DIFF
--- a/app/assets/javascripts/editor.js
+++ b/app/assets/javascripts/editor.js
@@ -9,13 +9,14 @@ function (ko, models, tools, msg, validate, owned) {
      *
      * @param confId
      * @param abstrId
+     * @param isAdmin
      * @returns {EditorViewModel}
      * @constructor
      */
-    function EditorViewModel(confId, abstrId) {
+    function EditorViewModel(confId, abstrId, isAdmin) {
 
         if (! (this instanceof EditorViewModel)) {
-            return new EditorViewModel(confId, abstrId);
+            return new EditorViewModel(confId, abstrId, isAdmin);
         }
 
         var self = tools.inherit(this, msg.MessageVM);
@@ -133,12 +134,14 @@ function (ko, models, tools, msg, validate, owned) {
 
         // hide edit buttons, if the abstract is in any state other
         // than "inPreparation" or if its not a new submission
+        // but enable it for admins when the abstract is in the 'InRevision' state
         self.showEditButton = ko.computed(
             function () {
                 var saved = self.isAbstractSaved(),
                     state = self.originalState();
 
-                return !saved || (!state || state === 'InPreparation');
+                return !saved || (!state || state === 'InPreparation') ||
+                    (!state || state === 'InRevision' && isAdmin === 'true');
             },
             self
         );
@@ -643,8 +646,9 @@ function (ko, models, tools, msg, validate, owned) {
 
         console.log(data["conferenceUuid"]);
         console.log(data["abstractUuid"]);
+        console.log(data["isadmin"]);
 
-        window.editor = EditorViewModel(data["conferenceUuid"], data["abstractUuid"]);
+        window.editor = EditorViewModel(data["conferenceUuid"], data["abstractUuid"], data["isadmin"]);
         window.editor.init();
     });
 

--- a/app/assets/javascripts/userdash.js
+++ b/app/assets/javascripts/userdash.js
@@ -4,17 +4,17 @@ require(["lib/models", "lib/tools", "knockout", "sammy"], function (models, tool
 
 
     /**
-     * AbstractList view model.
+     * UserDash view model.
      *
      *
-     * @param confId
-     * @returns {AbstractListViewModel}
+     * @param isAdmin
+     * @returns {UserDashViewModel}
      * @constructor
      */
-    function UserDashViewModel() {
+    function UserDashViewModel(isAdmin) {
 
         if (!(this instanceof UserDashViewModel)) {
-            return new UserDashViewModel();
+            return new UserDashViewModel(isAdmin);
         }
 
         var self = this;
@@ -84,7 +84,7 @@ require(["lib/models", "lib/tools", "knockout", "sammy"], function (models, tool
 
                         abstr.viewEditCtx = ko.computed(function () {
                             var confIsOpen = currentConf.isOpen;
-                            var canEdit = abstr.state == "InRevision" ||
+                            var canEdit = (abstr.state == "InRevision" && isAdmin === 'true') ||
                                 (confIsOpen && (abstr.state == "InPreparation" ||
                                 abstr.state == "Submitted" ||
                                 abstr.state == "Withdrawn"));
@@ -121,8 +121,9 @@ require(["lib/models", "lib/tools", "knockout", "sammy"], function (models, tool
 
         var data = tools.hiddenData();
 
+        console.log(data["isadmin"]);
 
-        window.dashboard = UserDashViewModel();
+        window.dashboard = UserDashViewModel(data["isadmin"]);
         window.dashboard.init();
     });
 

--- a/app/views/dashboard/user.scala.html
+++ b/app/views/dashboard/user.scala.html
@@ -4,6 +4,7 @@
 
     <div class="hidden-data">
         <div id="conference-uuid">@account.uuid</div>
+        <div id="isadmin">@account.isAdmin</div>
     </div>
 
     <script data-main="@routes.Assets.at("javascripts/userdash.js")"

--- a/app/views/submission.scala.html
+++ b/app/views/submission.scala.html
@@ -5,6 +5,7 @@
     <div class="hidden-data">
         <div id="conference-uuid">@conference.uuid</div>
         <div id="abstract_uuid">@abstr.map(_.uuid).getOrElse("")</div>
+        <div id="isadmin">@account.isAdmin</div>
     </div>
 
     <script data-main="@routes.Assets.at("javascripts/editor.js")"


### PR DESCRIPTION
Up until now it was possible for normal users to change their own abstracts, if they are in the 'InRevision' state, which should actually only be allowed for admin users.
This pull request restricts the editing of an abstract in the 'InRevision' state to admins only.