### PR TITLE
Tweak abstract editor

### DIFF
--- a/app/assets/javascripts/editor.js
+++ b/app/assets/javascripts/editor.js
@@ -81,20 +81,6 @@ function (ko, models, tools, msg, validate, owned) {
             self
         );
 
-        self.showButtonSave = ko.computed(
-            function () {
-                if (self.abstract()) {
-                    var saved = self.isAbstractSaved(),
-                        state = self.originalState();
-
-                    return !saved || !state || state === 'InPreparation' || state === 'InRevision';
-                } else {
-                    return false;
-                }
-            },
-            self
-        );
-
         self.showButtonSubmit = ko.computed(
             function () {
                 if (self.abstract()) {

--- a/app/assets/javascripts/editor.js
+++ b/app/assets/javascripts/editor.js
@@ -118,13 +118,13 @@ function (ko, models, tools, msg, validate, owned) {
         );
 
         // hide edit buttons, if the abstract is in any state other
-        // than "inPreparation" or if its not a new submission
+        // than "InPreparation" or "InRevision"
         self.showEditButton = ko.computed(
             function () {
                 var saved = self.isAbstractSaved(),
                     state = self.originalState();
 
-                return !saved || (!state || state === 'InPreparation');
+                return !saved || (!state || state === 'InPreparation' || state === 'InRevision');
             },
             self
         );

--- a/app/assets/stylesheets/layout.less
+++ b/app/assets/stylesheets/layout.less
@@ -360,3 +360,9 @@ body {
 .table-condensed {
   font-size: 13px;
 }
+
+.alert-text-only {
+  background-color: @color-bg;
+  border-color: @color-bg;
+}
+

--- a/app/views/submission.scala.html
+++ b/app/views/submission.scala.html
@@ -60,7 +60,12 @@
     <span data-bind="if: showEditButton">
         <div class="alert alert-info fade in out">
             <ul>
-                <li>Click the <b>Save</b> button to save new information or any changes to your abstract.</li>
+                <span data-bind="ifnot: isAbstractSaved">
+                    <li>Click the <b>Save</b> button once to save your abstract. Subsequent changes are saved automatically.</li>
+                </span>
+                <span data-bind="if: isAbstractSaved">
+                    <li>All changes to the abstract are saved automatically.</li>
+                </span>
                 <li>After entering all information, click the <b>Submit</b> button to submit your abstract.</li>
                 <li>Submitted abstracts can be modified until the deadline.<br/>
                     To edit a <b>submitted</b> abstract, withdraw and reactivate the abstract. Don't forget to re-submit after editing.</li>

--- a/app/views/submission.scala.html
+++ b/app/views/submission.scala.html
@@ -58,7 +58,7 @@
 
     <!-- display submission information -->
     <span data-bind="if: showEditButton">
-        <div class="alert alert-info fade in out">
+        <div class="alert alert-info alert-text-only">
             <ul>
                 <span data-bind="ifnot: isAbstractSaved">
                     <li>Click the <b>Save</b> button once to save your abstract. Subsequent changes are saved automatically.</li>
@@ -73,7 +73,7 @@
         </div>
     </span>
     <span data-bind="ifnot: showEditButton">
-        <div class="alert alert-danger fade in out">
+        <div class="alert alert-danger alert-text-only">
             <ul>
                 <li>Submitted abstracts can be modified until the deadline.<br/>
                     To edit a <b>submitted</b> abstract, withdraw and reactivate the abstract. Don't forget to re-submit after editing.</li>

--- a/app/views/submission.scala.html
+++ b/app/views/submission.scala.html
@@ -23,7 +23,7 @@
 
     <div class="header">
         <div class="pull-right state-btn-group">
-            <span data-bind="if: showButtonSave">
+            <span data-bind="ifnot: isAbstractSaved">
                 <button type="button" class="btn btn-success" data-bind="click: doSaveAbstract">
                     Save
                 </button>


### PR DESCRIPTION
Some changes to potentially unconfuse users
- show the save button only when an abstract has not been saved before, otherwise all changes are saved automatically anyway
- specify info texts describing what a user can and cannot do when the abstract is in a specifc state
- style these info texts to make them distinguishable from alerts
- display edit buttons only when an abstract is unsaved or in states 'InPreparation' or 'InRevision'