### PR TITLE
Schema changes for #309

### DIFF
--- a/app/models/Abstract.scala
+++ b/app/models/Abstract.scala
@@ -35,6 +35,8 @@ class Abstract extends Model with Owned {
   var sortId: Int = _
 
   @Convert(converter = classOf[DateTimeConverter])
+  var ctime: DateTime = _
+  @Convert(converter = classOf[DateTimeConverter])
   var mtime: DateTime = _
 
   @Convert(converter = classOf[AbstractStateConverter])

--- a/app/models/Account.scala
+++ b/app/models/Account.scala
@@ -15,7 +15,8 @@ import javax.persistence._
 import com.mohiva.play.silhouette.core.providers.PasswordInfo
 import com.mohiva.play.silhouette.core.{Identity, LoginInfo}
 import models.Model._
-import org.joda.time.LocalDateTime
+import models.util.DateTimeConverter
+import org.joda.time.{DateTime, LocalDateTime}
 import play.api.Play.current
 
 /**
@@ -31,6 +32,11 @@ class Account extends Model {
   var fullName: String = _
 
   var avatar: String = _
+
+  @Convert(converter = classOf[DateTimeConverter])
+  var ctime: DateTime = _
+  @Convert(converter = classOf[DateTimeConverter])
+  var mtime: DateTime = _
 
   @ManyToMany(mappedBy = "owners")
   var abstracts: JSet[Abstract] = new JTreeSet[Abstract]()

--- a/app/models/Conference.scala
+++ b/app/models/Conference.scala
@@ -37,6 +37,7 @@ class Conference extends Model with Owned {
 
   @Column(unique = true)
   var short: String = _
+  var conferenceGroup: String = _
   var cite: String = _
   var link: String = _
 

--- a/app/models/Conference.scala
+++ b/app/models/Conference.scala
@@ -59,6 +59,12 @@ class Conference extends Model with Owned {
   var thumbnail: String = _
 
   var iOSApp: String = _
+  @Column(length = 10000)
+  var geo: String = _
+  @Column(length = 100000)
+  var schedule: String = _
+  @Column(length = 10000)
+  var info: String = _
 
   @Convert(converter = classOf[DateTimeConverter])
   var ctime: DateTime = _

--- a/app/models/Conference.scala
+++ b/app/models/Conference.scala
@@ -46,6 +46,7 @@ class Conference extends Model with Owned {
   var isOpen: Boolean = _
   var isPublished: Boolean = _
   var isActive: Boolean = _
+  var hasPresentationPrefs: Boolean = _
 
   @Convert(converter = classOf[DateTimeConverter])
   var startDate: DateTime = _

--- a/app/models/Conference.scala
+++ b/app/models/Conference.scala
@@ -45,6 +45,7 @@ class Conference extends Model with Owned {
 
   var isOpen: Boolean = _
   var isPublished: Boolean = _
+  var isActive: Boolean = _
 
   @Convert(converter = classOf[DateTimeConverter])
   var startDate: DateTime = _

--- a/app/models/Conference.scala
+++ b/app/models/Conference.scala
@@ -59,6 +59,11 @@ class Conference extends Model with Owned {
 
   var iOSApp: String = _
 
+  @Convert(converter = classOf[DateTimeConverter])
+  var ctime: DateTime = _
+  @Convert(converter = classOf[DateTimeConverter])
+  var mtime: DateTime = _
+
   @OneToMany(mappedBy = "conference", cascade = Array(CascadeType.ALL), orphanRemoval = true)
   var groups: JSet[AbstractGroup] = new JTreeSet[AbstractGroup]()
 


### PR DESCRIPTION
Schema changes for all issues described in #309 

All changes are applied to the existing schema when GCA is started with `jpa.default=defaultPersistenceUnit`. 

Since newly created columns contain only `NULL`  entries the this [script](https://gist.github.com/stoewer/368fad64b2e299d38d9e) can be used to fill them with meaningful values.