### PR TITLE
Update field lengths

### DIFF
--- a/app/assets/javascripts/editor.js
+++ b/app/assets/javascripts/editor.js
@@ -56,13 +56,13 @@ function (ko, models, tools, msg, validate, owned) {
             self
         );
 
-        self.editorTextShowCharsLeft = ko.computed(
+        self.showAbstractTextCharsLeft = ko.computed(
             function () {
-                if (self.editedAbstract() && self.editedAbstract().text()
-                            || $('#text').attr('maxLength') != undefined) {
-                    return "Characters left: ";
+                var textCharLimit = $('#text').attr('maxLength');
+                if (self.editedAbstract() && self.editedAbstract().text() && textCharLimit !== undefined) {
+                    return true;
                 } else {
-                    return "";
+                    return textCharLimit !== undefined;
                 }
             },
             self
@@ -71,7 +71,7 @@ function (ko, models, tools, msg, validate, owned) {
         self.editorTextCharactersLeft = ko.computed(
             function () {
                 var textCharLimit = $('#text').attr('maxLength');
-                if (self.editedAbstract() && self.editedAbstract().text() && textCharLimit != undefined) {
+                if (self.editedAbstract() && self.editedAbstract().text() && textCharLimit !== undefined) {
                     return textCharLimit - self.editedAbstract().text().length;
                 } else {
                     return textCharLimit;
@@ -80,13 +80,13 @@ function (ko, models, tools, msg, validate, owned) {
             self
         );
 
-        self.editorAckShowCharsLeft = ko.computed(
+        self.showAckCharsLeft = ko.computed(
             function () {
-                if (self.editedAbstract() && self.editedAbstract().acknowledgements()
-                            || $('#acknowledgements').attr('maxLength') != undefined) {
-                    return "Characters left: ";
+                var ackCharLimit = $('#acknowledgements').attr('maxLength');
+                if (self.editedAbstract() && self.editedAbstract().acknowledgements() && ackCharLimit !== undefined) {
+                    return true;
                 } else {
-                    return "";
+                    return ackCharLimit !== undefined;
                 }
             },
             self
@@ -95,7 +95,7 @@ function (ko, models, tools, msg, validate, owned) {
         self.editorAckCharactersLeft = ko.computed(
             function () {
                 var ackCharLimit = $('#acknowledgements').attr('maxLength');
-                if (self.editedAbstract() && self.editedAbstract().acknowledgements() && ackCharLimit != undefined) {
+                if (self.editedAbstract() && self.editedAbstract().acknowledgements() && ackCharLimit !== undefined) {
                     return ackCharLimit - self.editedAbstract().acknowledgements().length;
                 } else {
                     return ackCharLimit;

--- a/app/assets/javascripts/editor.js
+++ b/app/assets/javascripts/editor.js
@@ -21,8 +21,8 @@ function (ko, models, tools, msg, validate, owned) {
         var self = tools.inherit(this, msg.MessageVM);
         self = tools.inherit(self, owned.Owned);
 
-        self.textCharacterLimit = 2000;
-        self.ackCharacterLimit = 200;
+        self.textCharacterLimit = 2500;
+        self.ackCharacterLimit = 300;
 
         self.conference = ko.observable(null);
         self.abstract = ko.observable(null);

--- a/app/assets/javascripts/editor.js
+++ b/app/assets/javascripts/editor.js
@@ -21,9 +21,6 @@ function (ko, models, tools, msg, validate, owned) {
         var self = tools.inherit(this, msg.MessageVM);
         self = tools.inherit(self, owned.Owned);
 
-        self.textCharacterLimit = 2500;
-        self.ackCharacterLimit = 300;
-
         self.conference = ko.observable(null);
         self.abstract = ko.observable(null);
         self.editedAbstract = ko.observable(null);
@@ -59,12 +56,37 @@ function (ko, models, tools, msg, validate, owned) {
             self
         );
 
+        self.editorTextShowCharsLeft = ko.computed(
+            function () {
+                if (self.editedAbstract() && self.editedAbstract().text()
+                            || $('#text').attr('maxLength') != undefined) {
+                    return "Characters left: ";
+                } else {
+                    return "";
+                }
+            },
+            self
+        );
+
         self.editorTextCharactersLeft = ko.computed(
             function () {
-                if (self.editedAbstract() && self.editedAbstract().text()) {
-                    return self.textCharacterLimit - self.editedAbstract().text().length;
+                var textCharLimit = $('#text').attr('maxLength');
+                if (self.editedAbstract() && self.editedAbstract().text() && textCharLimit != undefined) {
+                    return textCharLimit - self.editedAbstract().text().length;
                 } else {
-                    return self.textCharacterLimit;
+                    return textCharLimit;
+                }
+            },
+            self
+        );
+
+        self.editorAckShowCharsLeft = ko.computed(
+            function () {
+                if (self.editedAbstract() && self.editedAbstract().acknowledgements()
+                            || $('#acknowledgements').attr('maxLength') != undefined) {
+                    return "Characters left: ";
+                } else {
+                    return "";
                 }
             },
             self
@@ -72,10 +94,11 @@ function (ko, models, tools, msg, validate, owned) {
 
         self.editorAckCharactersLeft = ko.computed(
             function () {
-                if (self.editedAbstract() && self.editedAbstract().acknowledgements()) {
-                    return self.ackCharacterLimit - self.editedAbstract().acknowledgements().length;
+                var ackCharLimit = $('#acknowledgements').attr('maxLength');
+                if (self.editedAbstract() && self.editedAbstract().acknowledgements() && ackCharLimit != undefined) {
+                    return ackCharLimit - self.editedAbstract().acknowledgements().length;
                 } else {
-                    return self.ackCharacterLimit;
+                    return ackCharLimit;
                 }
             },
             self
@@ -488,6 +511,10 @@ function (ko, models, tools, msg, validate, owned) {
             self.modalHeader("header-"+ editorId.replace('#',''));
             // load corresponding script for modal body
             self.modalBody("body-"+ editorId.replace('#',''));
+
+            var textCharLimit = $('#text').attr('maxLength');
+            var ackCharLimit = $('#acknowledgements').attr('maxLength');
+
         };
 
 

--- a/app/assets/stylesheets/layout.less
+++ b/app/assets/stylesheets/layout.less
@@ -286,7 +286,7 @@ body {
 
   .abstract-text:empty::after {
     color: @color-fg-light;
-    content: "4. Enter abstract text (up to 2000 characters)";
+    content: "4. Enter abstract text";
   }
 
   .acknowledgements{

--- a/app/models/Abstract.scala
+++ b/app/models/Abstract.scala
@@ -27,6 +27,7 @@ class Abstract extends Model with Owned {
   var text:  String = _
   var doi:   String = _
   var conflictOfInterest: String = _
+  @Column(length=300)
   var acknowledgements: String = _
 
   var isTalk: Boolean = false

--- a/app/models/Conference.scala
+++ b/app/models/Conference.scala
@@ -13,12 +13,8 @@ import models.Model._
 import java.util.{Set => JSet, TreeSet => JTreeSet}
 import javax.persistence._
 import org.joda.time.DateTime
-import org.joda.time.format.{DateTimeFormat, DateTimeFormatter}
-import scala.Some
+import org.joda.time.format.DateTimeFormat
 import models.util.DateTimeConverter
-import scala.collection.JavaConversions._
-import scala.Some
-
 
 
 /**
@@ -40,6 +36,7 @@ class Conference extends Model with Owned {
   var cite: String = _
   var link: String = _
 
+  @Column(length=512)
   var description: String = _
 
   var isOpen: Boolean = _
@@ -71,7 +68,7 @@ class Conference extends Model with Owned {
   var topics: JSet[Topic] = new JTreeSet[Topic]()
 }
 
-object Conference {
+object Conference extends Model {
 
   def apply(uuid: Option[String],
             name: Option[String],

--- a/app/models/Figure.scala
+++ b/app/models/Figure.scala
@@ -10,7 +10,7 @@
 package models
 
 import models.Model._
-import javax.persistence.{ManyToOne, Entity}
+import javax.persistence.{Column, ManyToOne, Entity}
 
 /**
  * A model for figures.
@@ -18,6 +18,7 @@ import javax.persistence.{ManyToOne, Entity}
 @Entity
 class Figure extends PositionedModel {
 
+  @Column(length=300)
   var caption: String = _
 
   @ManyToOne

--- a/app/models/Model.scala
+++ b/app/models/Model.scala
@@ -12,6 +12,7 @@ package models
 import collection.JavaConversions.asJavaCollection
 import java.util.{Set => JSet, TreeSet => JTreeSet, UUID}
 import javax.persistence.{PrePersist, Id, MappedSuperclass}
+import scala.reflect.runtime.universe._
 
 /**
  * Trait that defines stuff that is common for all models.
@@ -60,7 +61,6 @@ object Model {
    * Unwrap an optional value.
    *
    * @param value The optional value.
-   *
    * @return The value wrapped by Some or 0
    */
   def unwrapVal[T: Numeric](value: Option[T]) = {
@@ -74,7 +74,6 @@ object Model {
    * Unwrap an optional reference.
    *
    * @param value An optional value
-   *
    * @return The value wrapped by Some or null
    */
   def unwrapRef[T >: Null](value: Option[T]) : T = {
@@ -87,7 +86,6 @@ object Model {
   /**
    *
    * @param seq The sequence to convert.
-   *
    * @return A list
    */
   def toJSet[T](seq : Seq[T]) : JSet[T] = {
@@ -97,6 +95,25 @@ object Model {
     }
   }
 
+  def membersAnnotations[T: TypeTag]: Map[String, Map[String, Map[String, Any]]] = {
+    typeOf[T].members.withFilter {
+      _.annotations.length > 0
+    }.map { m =>
+      m.name.toString.trim -> m.annotations.map { a =>
+        a.tree.tpe.typeSymbol.name.toString.trim -> a.tree.children.withFilter {
+          _.productPrefix eq "AssignOrNamedArg"
+        }.map { tree =>
+          tree.productElement(0).toString.trim -> tree.productElement(1)
+        }.toMap
+      }.toMap
+    }.toMap
+  }
+
+  def getLimit[T :TypeTag](name: String): Int = {
+    membersAnnotations[T].get(name).flatMap(_.get("Column")).flatMap(_.get("length")).map {
+      x => x.asInstanceOf[Literal].value.value.asInstanceOf[Int]
+    }.getOrElse(255)
+  }
 
 }
 

--- a/app/models/Reference.scala
+++ b/app/models/Reference.scala
@@ -10,7 +10,7 @@
 package models
 
 import models.Model._
-import javax.persistence.{ManyToOne, Entity}
+import javax.persistence.{Column, ManyToOne, Entity}
 
 /**
  * Very simple model for referenced literature.
@@ -18,6 +18,7 @@ import javax.persistence.{ManyToOne, Entity}
 @Entity
 class Reference extends PositionedModel {
 
+  @Column(length=300)
   var text: String = _
   var link: String = _
   var doi: String = _

--- a/app/views/dashboard/admin/conference.scala.html
+++ b/app/views/dashboard/admin/conference.scala.html
@@ -61,7 +61,8 @@
                     <label for="name" class="col-sm-2 control-label">Name</label>
                     <div class="col-sm-10">
                         <input type="text" class="form-control" id="name"
-                               placeholder="Name" data-bind="value: name, valueUpdate: 'afterkeydown'">
+                                placeholder="Name" data-bind="value: name, valueUpdate: 'afterkeydown'"
+                                maxlength="@Model.getLimit[Conference]("name")">
                     </div>
                 </div>
 
@@ -69,7 +70,8 @@
                     <label for="short" class="col-sm-2 control-label">Short</label>
                     <div class="col-sm-10">
                         <input type="text" class="form-control" id="short"
-                               placeholder="Short name" data-bind="value: short, valueUpdate: 'afterkeydown'">
+                                placeholder="Short name" data-bind="value: short, valueUpdate: 'afterkeydown'"
+                                maxlength="@Model.getLimit[Conference]("short")">
                     </div>
                 </div>
 
@@ -77,7 +79,8 @@
                     <label for="cite" class="col-sm-2 control-label">Cite</label>
                     <div class="col-sm-10">
                         <input type="text" class="form-control" id="short"
-                              placeholder="Cite text" data-bind="value: cite, valueUpdate: 'afterkeydown'">
+                                placeholder="Cite text" data-bind="value: cite, valueUpdate: 'afterkeydown'"
+                                maxlength="@Model.getLimit[Conference]("short")">
                     </div>
                 </div>
 
@@ -85,7 +88,7 @@
                     <label for="start" class="col-sm-2 control-label">Start</label>
                     <div class="col-sm-10">
                         <input type="datetime" class="form-control" id="start"
-                              placeholder="" data-bind="datetimepicker: start">
+                                placeholder="Start date" data-bind="datetimepicker: start">
                     </div>
                 </div>
 
@@ -93,7 +96,7 @@
                     <label for="end" class="col-sm-2 control-label">End</label>
                     <div class="col-sm-10">
                         <input type="datetime" class="form-control" id="end"
-                              placeholder="" data-bind="datetimepicker: end">
+                                placeholder="End date" data-bind="datetimepicker: end">
                     </div>
                 </div>
 
@@ -101,7 +104,7 @@
                     <label for="deadline" class="col-sm-2 control-label">Deadline</label>
                     <div class="col-sm-10">
                         <input type="datetime" class="form-control" id="deadline"
-                              placeholder="" data-bind="datetimepicker: deadline">
+                                placeholder="Abstract submission deadline" data-bind="datetimepicker: deadline">
                     </div>
                 </div>
 
@@ -109,16 +112,18 @@
                     <label for="logo" class="col-sm-2 control-label">Logo</label>
                     <div class="col-sm-10">
                         <input type="url" class="form-control" id="logo"
-                               placeholder="Banner Logo" data-bind="value: logo, valueUpdate: 'afterkeydown'">
+                                placeholder="Banner Logo url" data-bind="value: logo, valueUpdate: 'afterkeydown'"
+                                maxlength="@Model.getLimit[Conference]("logo")">
                     </div>
                 </div>
 
                 <div class="form-group">
                     <label for="thumbnail" class="col-sm-2 control-label">Thumbnail</label>
                     <div class="col-sm-10">
-                        <input type="url" class="form-control" id="short"
-                               placeholder="Thumbnail image"
-                               data-bind="value: thumbnail, valueUpdate: 'afterkeydown'">
+                        <input type="url" class="form-control" id="thumbnail"
+                                placeholder="Thumbnail image url"
+                                data-bind="value: thumbnail, valueUpdate: 'afterkeydown'"
+                                maxlength="@Model.getLimit[Conference]("thumbnail")">
                     </div>
                 </div>
 
@@ -126,7 +131,8 @@
                     <label for="iosapp" class="col-sm-2 control-label">iOS App</label>
                     <div class="col-sm-10">
                         <input type="text" class="form-control" id="iosapp"
-                        placeholder="iOS App id" data-bind="value: iOSApp, valueUpdate: 'afterkeydown'">
+                                placeholder="iOS App id" data-bind="value: iOSApp, valueUpdate: 'afterkeydown'"
+                                maxlength="@Model.getLimit[Conference]("iOSApp")">
                     </div>
                 </div>
 
@@ -134,8 +140,9 @@
                     <label for="link" class="col-sm-2 control-label">Link</label>
                     <div class="col-sm-10">
                         <input type="url" class="form-control" id="link"
-                               placeholder="Link to the conference homepage"
-                               data-bind="value: link, valueUpdate: 'afterkeydown'">
+                                placeholder="Link to the conference homepage"
+                                data-bind="value: link, valueUpdate: 'afterkeydown'"
+                                maxlength="@Model.getLimit[Conference]("link")">
                     </div>
                 </div>
 
@@ -143,8 +150,9 @@
                     <label for="desc" class="col-sm-2 control-label">Description</label>
                     <div class="col-sm-10">
                         <textarea class="form-control" id="desc" rows="4"
-                        placeholder="Conference description"
-                        data-bind="value: description, valueUpdate: 'afterkeydown'"></textarea>
+                                placeholder="Conference description (max. @Model.getLimit[Conference]("description") characters)"
+                                data-bind="value: description, valueUpdate: 'afterkeydown'"
+                                maxlength="@Model.getLimit[Conference]("description")"></textarea>
                     </div>
                 </div>
 
@@ -159,7 +167,8 @@
 
                 <div class="form-group">
                     <div class="col-sm-offset-2 col-sm-4">
-                        <input class="form-control" type="text" placeholder="topic" id="addTopic">
+                        <input class="form-control" type="text" placeholder="topic" id="addTopic"
+                                maxlength="@Model.getLimit[Topic]("topic")">
                     </div>
                     <div class="col-sm-1">
                         <a class="btn btn-default" data-bind="click: $root.addTopic">
@@ -191,9 +200,18 @@
                 <tbody>
                     <!-- ko foreach: groups -->
                     <tr>
-                        <td><input class="form-control" data-bind="value: prefix, valueUpdate: 'afterkeydown'" type="text"></td>
-                        <td><input class="form-control" data-bind="value: short, valueUpdate: 'afterkeydown'" type="text"></td>
-                        <td><input class="form-control" data-bind="value: name, valueUpdate: 'afterkeydown'" type="text"></td>
+                        <td>
+                            <input class="form-control" data-bind="value: prefix, valueUpdate: 'afterkeydown'"
+                                    type="text" maxlength="@Model.getLimit[AbstractGroup]("prefix")">
+                        </td>
+                        <td>
+                            <input class="form-control" data-bind="value: short, valueUpdate: 'afterkeydown'"
+                                    type="text" maxlength="@Model.getLimit[AbstractGroup]("short")">
+                        </td>
+                        <td>
+                            <input class="form-control" data-bind="value: name, valueUpdate: 'afterkeydown'"
+                                    type="text" maxlength="@Model.getLimit[AbstractGroup]("name")">
+                        </td>
                         <td>
                             <button class="btn btn-danger btn-xs" data-bind="click: $root.removeGroup">
                                 <span class="glyphicon glyphicon-remove icon-no-gap"> Remove</span>
@@ -202,9 +220,18 @@
                     </tr>
                     <!-- /ko -->
                     <tr id="newGroup">
-                        <td><input id="ngPrefix" class="form-control" type="text"></td>
-                        <td><input id="ngShort" class="form-control" type="text"></td>
-                        <td><input id="ngName" class="form-control" type="text"></td>
+                        <td>
+                            <input id="ngPrefix" class="form-control" type="text"
+                                    maxlength="@Model.getLimit[AbstractGroup]("prefix")">
+                        </td>
+                        <td>
+                            <input id="ngShort" class="form-control" type="text"
+                                    maxlength="@Model.getLimit[AbstractGroup]("short")">
+                        </td>
+                        <td>
+                            <input id="ngName" class="form-control" type="text"
+                                    maxlength="@Model.getLimit[AbstractGroup]("name")">
+                        </td>
                         <td>
                             <button class="btn btn-primary btn-xs" data-bind="click: $root.addGroup">
                                 <span class="glyphicon glyphicon-plus icon-no-gap"> Create</span>

--- a/app/views/submission.scala.html
+++ b/app/views/submission.scala.html
@@ -441,7 +441,7 @@
             <span>LaTeX-like equation typesetting is supported via MathJax. Use $$ and $ (inline).
                 <a target="_blank" href="http://meta.math.stackexchange.com/questions/5020/mathjax-basic-tutorial-and-quick-reference">Quick guide</a>
             </span><br>
-            <span data-bind="text: editorTextShowCharsLeft"></span><span data-bind="text: editorTextCharactersLeft"></span>
+            <span data-bind="if: showAbstractTextCharsLeft">Characters left: </span><span data-bind="text: editorTextCharactersLeft"></span>
         </div>
     </script>
 
@@ -455,7 +455,7 @@
                 maxlength="@Model.getLimit[Abstract]("acknowledgements")">
         </textarea>
         <div>
-            <span data-bind="text: editorAckShowCharsLeft"></span><span data-bind="text: editorAckCharactersLeft"></span>
+            <span data-bind="if: showAckCharsLeft">Characters left: </span><span data-bind="text: editorAckCharactersLeft"></span>
         </div>
     </script>
 

--- a/app/views/submission.scala.html
+++ b/app/views/submission.scala.html
@@ -277,8 +277,10 @@
     </script>
     <script id="body-title-editor" type="text/html">
         <label for="title"></label>
-        <input type="text" class="form-control" id="title" maxlength="255"
-            data-bind="value: editedAbstract().title" placeholder="Title (max. 255 characters)" />
+        <input type="text" class="form-control" id="title"
+                placeholder="Title (max. @Model.getLimit[Abstract]("title") characters)"
+                data-bind="value: editedAbstract().title"
+                maxlength="@Model.getLimit[Abstract]("title")"/>
     </script>
 
     <!-- authors templates -->
@@ -299,19 +301,23 @@
                     </td>
                     <td>
                         <input type="text" class="form-control input-sm" placeholder="First Name"
-                        maxlength="100" data-bind="value: person.firstName" />
+                                maxlength="@Model.getLimit[Author]("firstName")"
+                                data-bind="value: person.firstName" />
                     </td>
                     <td>
                         <input type="text" class="form-control input-sm" placeholder="Middle Name"
-                        maxlength="100" data-bind="value: person.middleName" />
+                                maxlength="@Model.getLimit[Author]("middleName")"
+                                data-bind="value: person.middleName" />
                     </td>
                     <td>
                         <input type="text" class="form-control input-sm" placeholder="Last Name"
-                        maxlength="100" data-bind="value: person.lastName" />
+                                maxlength="@Model.getLimit[Author]("lastName")"
+                                data-bind="value: person.lastName" />
                     </td>
                     <td>
                         <input type="text" class="form-control input-sm" placeholder="Mail"
-                        maxlength="100" data-bind="value: person.mail" />
+                                maxlength="@Model.getLimit[Author]("mail")"
+                                data-bind="value: person.mail" />
                     </td>
                     <td>
                         <div class="btn-group pull-right">
@@ -347,19 +353,23 @@
                 <tr class="affiliation-form">
                     <td>
                         <input type="text" class="form-control input-sm" placeholder="Department"
-                        maxlength="100" data-bind="value: affiliation.department" />
+                                maxlength="@Model.getLimit[Affiliation]("department")"
+                                data-bind="value: affiliation.department" />
                     </td>
                     <td>
                         <input type="text" class="form-control input-sm" placeholder="Institution"
-                        maxlength="100" data-bind="value: affiliation.section" />
+                                maxlength="@Model.getLimit[Affiliation]("section")"
+                                data-bind="value: affiliation.section" />
                     </td>
                     <td>
                         <input type="text" class="form-control input-sm" placeholder="Address"
-                        maxlength="100" data-bind="value: affiliation.address" />
+                                maxlength="@Model.getLimit[Affiliation]("address")"
+                                data-bind="value: affiliation.address" />
                     </td>
                     <td>
                         <input type="text" class="form-control input-sm" placeholder="Country"
-                        maxlength="100" data-bind="value: affiliation.country" />
+                                maxlength="@Model.getLimit[Affiliation]("country")"
+                                data-bind="value: affiliation.country" />
                     </td>
                     <td>
                         <div class="btn-group pull-right">
@@ -423,12 +433,13 @@
         <h3>Enter the Abstract Text</h3>
     </script>
     <script id="body-abstract-text-editor" type="text/html">
-        <textarea rows="10" class="form-control" id="text" maxlength="2000"
-        data-bind="value: editedAbstract().text, valueUpdate: 'afterkeydown'">
+        <textarea rows="10" class="form-control" id="text"
+                data-bind="value: editedAbstract().text, valueUpdate: 'afterkeydown'"
+                maxlength="@Model.getLimit[Abstract]("text")">
         </textarea>
         <div>
             <span>LaTeX-like equation typesetting is supported via MathJax. Use $$ and $ (inline).
-                <a target="_blank" href="http://meta.math.stackexchange.com/questions/5020/mathjax-basic-tutorial-and-quick-reference">Quick quide</a>
+                <a target="_blank" href="http://meta.math.stackexchange.com/questions/5020/mathjax-basic-tutorial-and-quick-reference">Quick guide</a>
             </span><br>
             <span>Characters left: </span><span data-bind="text: editorTextCharactersLeft"></span>
         </div>
@@ -439,8 +450,9 @@
         <h3>Enter Acknowledgements Text</h3>
     </script>
     <script id="body-acknowledgements-editor" type="text/html">
-        <textarea rows="10" class="form-control" id="text" maxlength="200"
-        data-bind="value: editedAbstract().acknowledgements, valueUpdate: 'afterkeydown'">
+        <textarea rows="10" class="form-control" id="text"
+                data-bind="value: editedAbstract().acknowledgements, valueUpdate: 'afterkeydown'"
+                maxlength="@Model.getLimit[Abstract]("acknowledgements")">
         </textarea>
         <div>
             <span>Characters left: </span><span data-bind="text: editorAckCharactersLeft"></span>
@@ -465,15 +477,18 @@
                     </td>
                     <td>
                         <input type="text" class="form-control input-sm" placeholder="Citation"
-                        maxlength="255" data-bind="value: reference.text" />
+                                maxlength="@Model.getLimit[Reference]("text")"
+                                data-bind="value: reference.text" />
                     </td>
                     <td>
                         <input type="text" class="form-control input-sm" placeholder="link"
-                        maxlength="255" data-bind="value: reference.link" />
+                                maxlength="@Model.getLimit[Reference]("link")"
+                                data-bind="value: reference.link" />
                     </td>
                     <td>
                         <input type="text" class="form-control input-sm" placeholder="DOI"
-                        maxlength="100" data-bind="value: reference.doi" />
+                                maxlength="@Model.getLimit[Reference]("doi")"
+                                data-bind="value: reference.doi" />
                     </td>
                     <td>
                         <div class="btn-group pull-right">
@@ -500,12 +515,14 @@
     <script id="body-figure-editor" type="text/html">
         <div data-bind="ifnot: hasAbstractFigures">
             <div class="form-group">
-                <input type="text" name="figure-caption" id="figure-caption" data-bind="value: newFigure.caption"
-                    maxlength="250" class="form-control input-sm" placeholder="Figure Caption (max. 250 characters)">
+                <input type="text" name="figure-caption" id="figure-caption" class="form-control input-sm"
+                    placeholder="Figure Caption (max. @Model.getLimit[Figure]("caption") characters)"
+                    maxlength="@Model.getLimit[Figure]("caption")"
+                    data-bind="value: newFigure.caption">
             </div>
             <div class="form-group">
                 <input type="file" name="figure-file" id="figure-file" data-bind="event: { change: getNewFigure }"
-                    maxlength="100" class="form-control input-sm">
+                    maxlength="250" class="form-control input-sm">
             </div>
             <div data-bind="ifnot: isAbstractSaved">
                 Note: the figure will be uploaded when the abstract is saved for the first time.
@@ -521,9 +538,9 @@
                 <img class="figure-image" src="" data-bind="attr: {src: abstract().figures()[0].URL}">
                 <div class="figure-caption">
                     <span>Figure 1: </span>
-                    <input type="text" name="figure-update-caption" id="figure-update-caption"
-                    maxlength="250" class="form-control input-sm"
-                    data-bind="value: abstract().figures()[0].caption, valueUpdate: 'afterkeydown'">
+                    <input type="text" name="figure-update-caption" id="figure-update-caption" class="form-control input-sm"
+                            maxlength="@Model.getLimit[Figure]("caption")"
+                            data-bind="value: abstract().figures()[0].caption, valueUpdate: 'afterkeydown'">
                 </div>
             </div>
         </div>
@@ -565,10 +582,10 @@
         </div>
         <div data-bind="if: editedAbstract().isTalk">
             <input type="text" class="form-control" placeholder="Why should this contribution be selected for an oral presentation?"
-            maxlength="100" data-bind="value: editedAbstract().reasonForTalk">
+                    maxlength="@Model.getLimit[Abstract]("reasonForTalk")"
+                    data-bind="value: editedAbstract().reasonForTalk">
         </div>
     </script>
-
 
     <!-- general footer used with all modals so far -->
     <script id="generalModalFooter" type="text/html">

--- a/app/views/submission.scala.html
+++ b/app/views/submission.scala.html
@@ -450,7 +450,7 @@
         <h3>Enter Acknowledgements Text</h3>
     </script>
     <script id="body-acknowledgements-editor" type="text/html">
-        <textarea rows="10" class="form-control" id="text"
+        <textarea rows="10" class="form-control" id="acknowledgements"
                 data-bind="value: editedAbstract().acknowledgements, valueUpdate: 'afterkeydown'"
                 maxlength="@Model.getLimit[Abstract]("acknowledgements")">
         </textarea>

--- a/app/views/submission.scala.html
+++ b/app/views/submission.scala.html
@@ -441,7 +441,7 @@
             <span>LaTeX-like equation typesetting is supported via MathJax. Use $$ and $ (inline).
                 <a target="_blank" href="http://meta.math.stackexchange.com/questions/5020/mathjax-basic-tutorial-and-quick-reference">Quick guide</a>
             </span><br>
-            <span>Characters left: </span><span data-bind="text: editorTextCharactersLeft"></span>
+            <span data-bind="text: editorTextShowCharsLeft"></span><span data-bind="text: editorTextCharactersLeft"></span>
         </div>
     </script>
 
@@ -455,7 +455,7 @@
                 maxlength="@Model.getLimit[Abstract]("acknowledgements")">
         </textarea>
         <div>
-            <span>Characters left: </span><span data-bind="text: editorAckCharactersLeft"></span>
+            <span data-bind="text: editorAckShowCharsLeft"></span><span data-bind="text: editorAckCharactersLeft"></span>
         </div>
     </script>
 


### PR DESCRIPTION
The maxlength of all Textfields and Textareas should automatically depend on the size of the corresponding database column.

- Added methods to Model.scala to retrieve the length of a Column from the field of a specific Backend model e.g. Conference or Abstract.
- Updated the Textfields and Textareas in all templates to use the Column size of the corresponding database fields as maxlength.
- Removed static text "(up to 2000 characters)" from style sheet.
- Updated methods to calculate remaining Textarea characters for abstract text and acknowledgements in editor.js to use the corresponding maxlength value from the submission template.
- Tested all field lengths with Abstract create/edit and Conferences create/edit.

Resolves issue #293
Resolves issue #312