### PR TITLE
Front end: Add map information to conference

### DIFF
--- a/app/assets/javascripts/admin-conference.js
+++ b/app/assets/javascripts/admin-conference.js
@@ -245,7 +245,7 @@ require(["lib/models", "lib/tools", "lib/owned", "knockout", "ko.sortable", "dat
             });
         };
 
-        self.hasConferenceUuid = ko.computed(function() {
+        self.isConferenceSaved = ko.computed(function() {
             if (self.conference() === null) {
                 return false;
             } else {

--- a/app/assets/javascripts/lib/models.js
+++ b/app/assets/javascripts/lib/models.js
@@ -264,11 +264,11 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
      * @public
      */
     function Conference(uuid, name, short, cite, link, description, isOpen, isPublished, isActive, hasPresentationPrefs,
-                        groups, start, end, deadline, logo, thumbnail, iOSApp, owners, abstracts, topics) {
+                        groups, start, end, deadline, logo, thumbnail, iOSApp, geo, owners, abstracts, topics) {
 
         if (! (this instanceof Conference)) {
             return new Conference(uuid, name, short, cite, link, description, isOpen, isPublished, isActive,
-                                  hasPresentationPrefs, groups, start, end, deadline, logo, thumbnail, iOSApp, owners,
+                                  hasPresentationPrefs, groups, start, end, deadline, logo, thumbnail, iOSApp, geo, owners,
                                   abstracts, topics);
         }
 
@@ -290,6 +290,7 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
         self.logo = logo || null;
         self.thumbnail = thumbnail || null;
         self.iOSApp = iOSApp || null;
+        self.geo = geo || null;
         self.owners = owners || [];
         self.abstracts = abstracts || [];
         self.topics = topics || [];

--- a/app/controllers/api/Conferences.scala
+++ b/app/controllers/api/Conferences.scala
@@ -144,7 +144,7 @@ class Conferences(implicit val env: Environment[Login, CachedCookieAuthenticator
   def getGeo(id: String) = SecuredAction { implicit request =>
     val geo = conferenceService.get(id).geo
     if (geo == null) {
-      NotFound(Json.obj("error" -> true))
+      NotFound(Json.obj("message" -> "No geo entry not found."))
     } else {
       Ok(Json.parse(geo))
     }

--- a/app/controllers/api/Conferences.scala
+++ b/app/controllers/api/Conferences.scala
@@ -144,7 +144,7 @@ class Conferences(implicit val env: Environment[Login, CachedCookieAuthenticator
   def getGeo(id: String) = SecuredAction { implicit request =>
     val geo = conferenceService.get(id).geo
     if (geo == null) {
-      NotFound(Json.obj("message" -> "No geo entry not found."))
+      NotFound(Json.obj("message" -> "Geo entry not found."))
     } else {
       Ok(Json.parse(geo))
     }

--- a/app/views/dashboard/admin/conference.scala.html
+++ b/app/views/dashboard/admin/conference.scala.html
@@ -259,6 +259,29 @@
             <button type="submit" class="btn btn-success"
                     data-bind="click: $root.saveConference, text: $root.saveButtonText, css { disabled: $root.saveButtonDisabled }">Save</button>
         </div>
+
+        <!-- Geo information management -->
+        <div data-bind="if: $root.hasConferenceUuid">
+            <hr>
+            <p class="lead">Geo information</p>
+            <table>
+                <tbody>
+                    <tr>
+                        <td class="col-xs-12">
+                            <textarea id="geoContent" class="form-control" rows="4"
+                                placeholder="Conference geo information. Requires well-formed JSON."
+                                data-bind="value: geoContent, valueUpdate: 'afterkeydown'"
+                                maxlength="@Model.getLimit[Conference]("geo")"></textarea>
+                        </td>
+                        <td>
+                            <button type="submit" class="btn btn-success"
+                                data-bind="click: $root.uploadGeo">Upload</button>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+
         <hr>
 
         <!-- owner management with owned component -->

--- a/app/views/dashboard/admin/conference.scala.html
+++ b/app/views/dashboard/admin/conference.scala.html
@@ -261,7 +261,7 @@
         </div>
 
         <!-- Geo information management -->
-        <div data-bind="if: $root.hasConferenceUuid">
+        <div data-bind="if: $root.isConferenceSaved">
             <hr>
             <p class="lead">Geo information</p>
             <table>

--- a/test/controller/ConferenceCtrlTest.scala
+++ b/test/controller/ConferenceCtrlTest.scala
@@ -167,7 +167,8 @@ class ConferenceCtrlTest extends BaseCtrlTest {
     val response = route(ConferenceCtrlTest.app, reqEmpty).get
 
     assert(status(response) == NOT_FOUND)
-    assert(contentAsJson(response).asInstanceOf[JsObject].values.head.asInstanceOf[JsBoolean].value.equals(true))
+    assert(contentAsJson(response).asInstanceOf[JsObject]
+      .values.head.asInstanceOf[JsString].value.equals("Geo entry not found."))
   }
 
   @Test


### PR DESCRIPTION
- Added conference field geo to the jsModel
- Added GET and PUT methods to admin-conference.js
- Added geo textarea to the view, textarea and upload button are only visible, if the conference already exists.
- Conference controller getGeo now returns an error message, if no geo entry exists for a conference instead of just "error": "true".

This pull request closes issue #303.