### PR TITLE
[editor] state workflow rework

### DIFF
--- a/app/assets/javascripts/editor.js
+++ b/app/assets/javascripts/editor.js
@@ -557,6 +557,15 @@ function (ko, models, tools, msg, validate, owned, astate) {
         self.doChangeState = function(toState) {
             var data = {state: toState};
 
+            if (toState === "Submitted") {
+                var result = validate.abstract(self.abstract());
+                if (! result.ok()) {
+                    self.setError("Error", "Unable to submit: " +
+                        (result.hasErrors() ? result.errors[0] : result.warnings[0]));
+                    return;
+                }
+            }
+
             $.ajax("/api/abstracts/" + self.abstract().uuid + '/state', {
                 data: JSON.stringify(data),
                 type: "PUT",

--- a/app/assets/javascripts/editor.js
+++ b/app/assets/javascripts/editor.js
@@ -328,11 +328,6 @@ function (ko, models, tools, msg, validate, owned, astate) {
                 return;
             }
 
-            if (abstract.state() === "Submitted" && result.hasWarnings()) {
-                self.setError("Error", "Unable to save abstract: " + result.warnings[0]);
-                return;
-            }
-
             if (self.isAbstractSaved()) {
 
                 if (self.hasAbstractFigures()) {

--- a/app/assets/javascripts/editor.js
+++ b/app/assets/javascripts/editor.js
@@ -132,17 +132,7 @@ function (ko, models, tools, msg, validate, owned, astate) {
             },
             self
         );
-
-        self.showButtonReactivate = ko.computed(
-            function () {
-                var saved = self.isAbstractSaved(),
-                    state = self.originalState();
-
-                return saved && (!state || state === 'Withdrawn');
-            },
-            self
-        );
-
+        
         // hide edit buttons, if the abstract is in any state other
         // than "InPreparation" or "InRevision"
         self.showEditButton = ko.computed(
@@ -490,12 +480,6 @@ function (ko, models, tools, msg, validate, owned, astate) {
 
         self.doWithdrawAbstract = function () {
             self.abstract().state('Withdrawn');
-            self.doSaveAbstract(self.abstract())
-        };
-
-
-        self.doReactivateAbstract = function () {
-            self.abstract().state('InPreparation');
             self.doSaveAbstract(self.abstract())
         };
 

--- a/app/assets/javascripts/editor.js
+++ b/app/assets/javascripts/editor.js
@@ -1,6 +1,6 @@
 require(["main"], function () {
-require(["knockout", "lib/models", "lib/tools", "lib/msg", "lib/validate", "lib/owned", "ko.sortable"],
-function (ko, models, tools, msg, validate, owned) {
+require(["knockout", "lib/models", "lib/tools", "lib/msg", "lib/validate", "lib/owned", "lib/astate", "ko.sortable"],
+function (ko, models, tools, msg, validate, owned, astate) {
     "use strict";
 
     /**
@@ -41,6 +41,9 @@ function (ko, models, tools, msg, validate, owned) {
 
         // required to affiliate and author with a department
         self.selectedAffiliationAuthor = 0;
+
+        // just a shortcut
+        self.stateHelper = astate.changeHelper;
 
         self.isAbstractSaved = ko.computed(
             function () {
@@ -182,20 +185,9 @@ function (ko, models, tools, msg, validate, owned) {
             if (!saved) {
                 isOk = (newState === 'InPreparation' || newState === 'Submitted');
             } else {
-                switch (oldState) {
-                    case 'InPreparation':
-                        isOk = (newState === 'InPreparation' || newState === 'Submitted');
-                        break;
-                    case 'Submitted':
-                        isOk = (newState === 'Withdrawn');
-                        break;
-                    case 'Withdrawn':
-                        isOk = (newState === 'InPreparation');
-                        break;
-                    case 'InRevision':
-                        isOk = (newState === 'InRevision' || newState === 'Submitted');
-                        break;
-                }
+                var confIsClosed = !self.conference().isOpen;
+                isOk = newState === oldState ||
+                    self.stateHelper.canTransitionTo(oldState, newState, false, confIsClosed);
             }
 
             return isOk;

--- a/app/assets/javascripts/editor.js
+++ b/app/assets/javascripts/editor.js
@@ -416,10 +416,6 @@ function (ko, models, tools, msg, validate, owned, astate) {
             self.modalHeader("header-"+ editorId.replace('#',''));
             // load corresponding script for modal body
             self.modalBody("body-"+ editorId.replace('#',''));
-
-            var textCharLimit = $('#text').attr('maxLength');
-            var ackCharLimit = $('#acknowledgements').attr('maxLength');
-
         };
 
 

--- a/app/assets/javascripts/lib/astate.js
+++ b/app/assets/javascripts/lib/astate.js
@@ -17,8 +17,7 @@ define(["lib/tools", "moment"], function(tools, moment) {
             owner: {
                 isOpen: {
                     InPreparation: ["Submitted"],
-                    Submitted:     ["Withdrawn"],
-                    Withdrawn:     ["InPreparation"],
+                    Submitted:     ["InPreparation", "Withdrawn"],
                     InRevision:    ["Submitted"]
                 },
                 isClosed: {

--- a/app/assets/javascripts/lib/astate.js
+++ b/app/assets/javascripts/lib/astate.js
@@ -56,7 +56,7 @@ define(["lib/tools", "moment"], function(tools, moment) {
 
         self.canTransitionTo = function(fromState, toState, isAdmin, isClosed) {
             var possibleStates = self.getPossibleStatesFor(fromState, isAdmin, isClosed);
-            return toState in possibleStates;
+            return possibleStates.indexOf(toState) > -1;
         };
     }
 

--- a/app/assets/javascripts/lib/astate.js
+++ b/app/assets/javascripts/lib/astate.js
@@ -42,10 +42,10 @@ define(["lib/tools", "moment"], function(tools, moment) {
         };
 
         self.getActiveTransitionMap = function(isAdmin, isClosed) {
-            if(isAdmin) {
+            if (isAdmin) {
                 return self.transitionMap.admin;
             } else {
-                return self.owner[isClosed ? 'isClosed' : 'isOpen'];
+                return self.transitionMap.owner[isClosed ? 'isClosed' : 'isOpen'];
             }
         };
 

--- a/app/conf/Global.scala
+++ b/app/conf/Global.scala
@@ -65,6 +65,8 @@ object Global extends GlobalSettings with SecuredSettings {
         e.getCause match {
           case cause: IllegalArgumentException =>
             UnprocessableEntity(exceptionToJSON(cause))
+          case cause: IllegalAccessException =>
+            Forbidden(exceptionToJSON(cause))
           case _ => InternalServerError(exceptionToJSON(e))
         }
     }

--- a/app/models/AbstractState.scala
+++ b/app/models/AbstractState.scala
@@ -13,7 +13,7 @@ object AbstractState extends Enumeration {
    *                        ,----- Conference.isOpen                                                                  *
    *                       \/                                                                                         */
   val ownerStates = Map("isOpen"  -> Map(InPreparation -> (Submitted :: Nil),
-                                         Submitted     -> (InPreparation :: Nil),
+                                         Submitted     -> (InPreparation :: Withdrawn :: Nil),
                                          InRevision    -> (Submitted :: Nil)),
                        "isClosed" -> Map(InRevision    -> (Submitted :: Nil)))
 

--- a/app/models/AbstractState.scala
+++ b/app/models/AbstractState.scala
@@ -13,8 +13,7 @@ object AbstractState extends Enumeration {
    *                        ,----- Conference.isOpen                                                                  *
    *                       \/                                                                                         */
   val ownerStates = Map("isOpen"  -> Map(InPreparation -> (Submitted :: Nil),
-                                         Submitted     -> (Withdrawn :: Nil),
-                                         Withdrawn     -> (InPreparation :: Nil),
+                                         Submitted     -> (InPreparation :: Nil),
                                          InRevision    -> (Submitted :: Nil)),
                        "isClosed" -> Map(InRevision    -> (Submitted :: Nil)))
 

--- a/app/service/AbstractService.scala
+++ b/app/service/AbstractService.scala
@@ -271,12 +271,7 @@ class AbstractService(figPath: String) extends PermissionsBase {
 
       abstr.stateLog = abstrChecked.stateLog
       if(abstr.state != abstrChecked.state) {
-
-        //TODO: reject all state changes if abstr.state != InPreparation,
-        //TODO:   except for Submitted && Withdrawn
-
-        //state changed, add a log entry
-        abstr.stateLog.add(StateLogEntry(abstr, abstr.state, account))
+        throw new IllegalAccessException(s"Trying to change state via update [uuid = $abstr.uuid]")
       }
 
       arrangeAffiliations(abstr)

--- a/app/views/components/owned.scala.html
+++ b/app/views/components/owned.scala.html
@@ -2,7 +2,6 @@
 
 <!-- manage owners -->
 <div data-bind="visible: owners().length > 0">
-    <p class="lead">Owner Management</p>
     <p>Here is the list of current owners:</p>
     <ul data-bind="foreach: owners" class="unstyled">
         <li>

--- a/app/views/dashboard/admin/conference.scala.html
+++ b/app/views/dashboard/admin/conference.scala.html
@@ -285,6 +285,7 @@
         <hr>
 
         <!-- owner management with owned component -->
+        <p class="lead">Owner Management</p>
         @components.owned()
 
     </div> <!-- KO !flickerbox -->

--- a/app/views/submission.scala.html
+++ b/app/views/submission.scala.html
@@ -247,9 +247,21 @@
             </div>
         }
 
-        <div data-bind="if: isAbstractSaved">
-            <hr class="separator">
-            @components.owned()
+        <!-- Advanced abstract settings -->
+        <div>
+            <ul class="nav nav-pills" role="tablist">
+                <li role="presentation" data-bind="if: isAbstractSaved">
+                    <a href="#owner" aria-controls="owner" role="tab" data-toggle="tab">Owner Management</a>
+                </li>
+            </ul>
+
+            <!-- Tab panes -->
+            <div class="tab-content" data-bind="if: isAbstractSaved">
+                <div role="tabpanel" class="tab-pane" id="owner">
+                @components.owned()
+                </div>
+            </div>
+
         </div>
 
     </div>

--- a/app/views/submission.scala.html
+++ b/app/views/submission.scala.html
@@ -244,8 +244,11 @@
 
         <!-- Advanced abstract settings -->
         <div>
-            <ul class="nav nav-pills" role="tablist">
-                <li role="presentation" data-bind="if: isAbstractSaved">
+            <ul class="nav nav-tabs" role="tablist">
+                <li role="presentation" class="active" data-bind="if: stateLog">
+                    <a href="#statelog" aria-controls="statelog" role="tab" data-toggle="tab">State Log</a>
+                </li>
+                <li role="presentation" data-bind="if: showEditButton() && isAbstractSaved()">
                     <a href="#owner" aria-controls="owner" role="tab" data-toggle="tab">Owner Management</a>
                 </li>
                 <li role="presentation" data-bind="if: showButtonWithdraw">
@@ -254,8 +257,12 @@
             </ul>
 
             <!-- Tab panes -->
-            <div class="tab-content" data-bind="if: isAbstractSaved">
-                <div role="tabpanel" class="tab-pane" id="owner">
+            <div class="tab-content" data-bind="if: stateLog">
+                <div role="tabpanel" class="tab-pane active" id="statelog">
+                @components.statelog("stateLog") { <div></div> }
+                </div>
+
+                <div role="tabpanel" class="tab-pane" id="owner" data-bind="if: showEditButton() && isAbstractSaved()">
                 @components.owned()
                 </div>
 

--- a/app/views/submission.scala.html
+++ b/app/views/submission.scala.html
@@ -32,13 +32,12 @@
             </span>
         </div>
 
-        <!-- display the current abstract status-->
-        <div>
+        <h3>Abstract submission  <small>@conference.name</small></h3>
+        <!-- display the current abstract status -->
+        <div data-bind="if: isAbstractSaved">
             Abstract status:
             <span class="badge" data-bind="text: abstract().state()"></span>
         </div>
-
-        <h2>Abstract submission  <small>@conference.name</small></h2>
     </div>
 
     <hr class="separator">

--- a/app/views/submission.scala.html
+++ b/app/views/submission.scala.html
@@ -23,11 +23,6 @@
 
     <div class="header">
         <div class="pull-right state-btn-group">
-            <span data-bind="if: showButtonWithdraw">
-                <button type="button" class="btn btn-danger"  data-bind="click: doWithdrawAbstract">
-                    Withdraw
-                </button>
-            </span>
             <span data-bind="if: action">
                 <!-- ko with: action -->
                 <button type="button" class="btn" data-bind="click: action, text: label, css: level">
@@ -253,6 +248,9 @@
                 <li role="presentation" data-bind="if: isAbstractSaved">
                     <a href="#owner" aria-controls="owner" role="tab" data-toggle="tab">Owner Management</a>
                 </li>
+                <li role="presentation" data-bind="if: showButtonWithdraw">
+                    <a href="#withdraw" aria-controls="withdraw" role="tab" data-toggle="tab">Withdraw</a>
+                </li>
             </ul>
 
             <!-- Tab panes -->
@@ -260,8 +258,20 @@
                 <div role="tabpanel" class="tab-pane" id="owner">
                 @components.owned()
                 </div>
-            </div>
 
+                <div role="tabpanel" class="tab-pane" id="withdraw" data-bind="if: showButtonWithdraw">
+                    <div class="callout-danger">
+                        <h4>Warning!</h4>
+                        <p>Abstract withdrawal is permanent! There is no way to recover the
+                           abstract yourself once it is withdrawn.
+                          <br>
+                            <button type="button" class="btn btn-danger"  data-bind="click: doWithdrawAbstract">
+                                Withdraw
+                            </button>
+                        </p>
+                    </div>
+                </div>
+            </div>
         </div>
 
     </div>

--- a/app/views/submission.scala.html
+++ b/app/views/submission.scala.html
@@ -23,20 +23,17 @@
 
     <div class="header">
         <div class="pull-right state-btn-group">
-            <span data-bind="ifnot: isAbstractSaved">
-                <button type="button" class="btn btn-success" data-bind="click: doSaveAbstract">
-                    Save
-                </button>
-            </span>
-            <span data-bind="if: showButtonSubmit">
-                <button type="button" class="btn btn-danger" data-bind="click: doSubmitAbstract">
-                    Submit
-                </button>
-            </span>
             <span data-bind="if: showButtonWithdraw">
                 <button type="button" class="btn btn-danger"  data-bind="click: doWithdrawAbstract">
                     Withdraw
                 </button>
+            </span>
+            <span data-bind="if: action">
+                <!-- ko with: action -->
+                <button type="button" class="btn" data-bind="click: action, text: label, css: level">
+                    Action
+                </button>
+                <!-- /ko -->
             </span>
         </div>
 
@@ -63,7 +60,7 @@
                 </span>
                 <li>After entering all information, click the <b>Submit</b> button to submit your abstract.</li>
                 <li>Submitted abstracts can be modified until the deadline.<br/>
-                    To edit a <b>submitted</b> abstract, withdraw and reactivate the abstract. Don't forget to re-submit after editing.</li>
+                    To edit a <b>submitted</b> abstract, unlock the abstract. Don't forget to re-submit after editing.</li>
             </ul>
         </div>
     </span>
@@ -72,7 +69,7 @@
             <ul>
                 <li>This abstract is submitted, changes are deactivated.<br/>
                     Submitted abstracts can be modified until the deadline.</li>
-                <li>To modify a submitted abstract, withdraw and reactivate the abstract.<br/>
+                <li>To modify a submitted abstract, unlock the abstract.<br/>
                     Don't forget to re-submit after editing.</li>
             </ul>
         </div>

--- a/app/views/submission.scala.html
+++ b/app/views/submission.scala.html
@@ -28,11 +28,6 @@
                     Save
                 </button>
             </span>
-            <span data-bind="if: showButtonReactivate">
-                <button type="button" class="btn btn-success" data-bind="click: doReactivateAbstract">
-                    Reactivate
-                </button>
-            </span>
             <span data-bind="if: showButtonSubmit">
                 <button type="button" class="btn btn-danger" data-bind="click: doSubmitAbstract">
                     Submit

--- a/app/views/submission.scala.html
+++ b/app/views/submission.scala.html
@@ -79,7 +79,7 @@
 
     <div id="abstract">
 
-        <div class="editor-box" data-bind="css: {editable: isChangeOk}">
+        <div class="editor-box" data-bind="css: {editable: showEditButton}">
             <div class="btn-group pull-right btn-group-hover" data-bind="if: showEditButton">
                 <button type="button" class="btn btn-default btn-sm" data-target="#title-editor" data-toggle="modal"
                         data-bind="click: doStartEdit.bind($root, '#title-editor')">
@@ -94,7 +94,7 @@
             </div>
         </div>
 
-        <div class="editor-box" data-bind="css: {editable: isChangeOk}">
+        <div class="editor-box" data-bind="css: {editable: showEditButton}">
             <div class="btn-group pull-right btn-group-hover" data-bind="if: showEditButton">
                 <button type="button" class="btn btn-default btn-sm" data-target="#authors-editor" data-toggle="modal"
                         data-bind="click: doStartEdit.bind($root, '#authors-editor')">
@@ -111,7 +111,7 @@
             </div>
         </div>
 
-        <div class="editor-box" data-bind="css: {editable: isChangeOk}">
+        <div class="editor-box" data-bind="css: {editable: showEditButton}">
             <div class="btn-group pull-right btn-group-hover" data-bind="if: showEditButton">
                 <button type="button" class="btn btn-default btn-sm" data-target="#affiliations-editor"
                         data-toggle="modal" data-bind="click: doStartEdit.bind($root, '#affiliations-editor')">
@@ -129,7 +129,7 @@
 
         </div>
 
-        <div class="editor-box" data-bind="css: {editable: isChangeOk}">
+        <div class="editor-box" data-bind="css: {editable: showEditButton}">
             <div class="btn-group pull-right btn-group-hover" data-bind="if: showEditButton">
                 <button type="button" class="btn btn-default btn-sm" data-target="#abstract-text-editor"
                         data-toggle="modal" data-bind="click: doStartEdit.bind($root, '#abstract-text-editor')">
@@ -144,7 +144,7 @@
             </div>
         </div>
 
-        <div class="editor-box" data-bind="css: {editable: isChangeOk}">
+        <div class="editor-box" data-bind="css: {editable: showEditButton}">
             <div class="btn-group pull-right btn-group-hover" data-bind="if: showEditButton">
                 <button type="button" class="btn btn-default btn-sm" data-target="#acknowledgements-editor"
                         data-toggle="modal" data-bind="click: doStartEdit.bind($root, '#acknowledgements-editor')">
@@ -160,7 +160,7 @@
             </div>
         </div>
 
-        <div class="editor-box" data-bind="css: {editable: isChangeOk}">
+        <div class="editor-box" data-bind="css: {editable: showEditButton}">
             <div class="btn-group pull-right btn-group-hover" data-bind="if: showEditButton">
                 <button type="button" class="btn btn-default btn-sm" data-target="#references-editor"
                         data-toggle="modal" data-bind="click: doStartEdit.bind($root, '#references-editor')">
@@ -178,7 +178,7 @@
             </div>
         </div>
 
-        <div class="editor-box" data-bind="css: {editable: isChangeOk}">
+        <div class="editor-box" data-bind="css: {editable: showEditButton}">
             <div class="btn-group pull-right btn-group-hover" data-bind="if: showEditButton">
                 <button type="button" class="btn btn-default btn-sm" data-target="#figure-editor"
                 data-toggle="modal" data-bind="click: doStartEdit.bind($root, '#figure-editor')">
@@ -206,7 +206,7 @@
         }
 
         @if(! conference.topics.isEmpty) {
-            <div class="editor-box" data-bind="css: {editable: isChangeOk}">
+            <div class="editor-box" data-bind="css: {editable: showEditButton}">
                 <div class="btn-group pull-right btn-group-hover" data-bind="if: showEditButton">
                     <button type="button" class="btn btn-default btn-sm" data-target="#topic-editor"
                     data-toggle="modal" data-bind="click: doStartEdit.bind($root, '#topic-editor')">
@@ -224,7 +224,7 @@
         }
 
         @if(conference.hasPresentationPrefs) {
-            <div class="editor-box" data-bind="css: {editable: isChangeOk}">
+            <div class="editor-box" data-bind="css: {editable: showEditButton}">
                 <div class="btn-group pull-right btn-group-hover" data-bind="if: showEditButton">
                     <button type="button" class="btn btn-default btn-sm" data-target="#is-talk-editor"
                     data-toggle="modal" data-bind="click: doStartEdit.bind($root, '#is-talk-editor')">

--- a/test/controller/AbstractsCtrlTest.scala
+++ b/test/controller/AbstractsCtrlTest.scala
@@ -102,6 +102,26 @@ class AbstractsCtrlTest extends BaseCtrlTest {
   }
 
   @Test
+  def testUpdateState() {
+
+    val original = assets.abstracts(0)
+
+    original.state = AbstractState.Withdrawn
+    val absUUID = original.uuid
+
+    val body = Json.toJson(original)
+    val reqNoAuth = FakeRequest(PUT, s"/api/abstracts/$absUUID").withJsonBody(body)
+
+    val reqNoAuthResult = route(AbstractsCtrlTest.app, reqNoAuth).get
+    assert(status(reqNoAuthResult) == UNAUTHORIZED)
+
+    val reqAuth = reqNoAuth.withCookies(cookie)
+
+    val reqAuthResult = routeWithErrors(AbstractsCtrlTest.app, reqAuth).get
+    assert(status(reqAuthResult) == FORBIDDEN)
+  }
+
+  @Test
   def testListByAccount() {
 
     val uid = assets.alice.uuid

--- a/test/service/AbstractServiceTest.scala
+++ b/test/service/AbstractServiceTest.scala
@@ -144,6 +144,15 @@ class AbstractServiceTest extends JUnitSuite {
     intercept[IllegalAccessException] {
       srv.update(original, assets.eve)
     }
+
+    // state changes are not allowed via the update API anymore
+    val stateChanged = assets.abstracts(0)
+    AbstractState.values.filter(stateChanged.state != _).foreach { v =>
+      stateChanged.state = v
+      intercept[IllegalAccessException] {
+        srv.update(stateChanged, assets.alice)
+      }
+    }
   }
 
   @Test


### PR DESCRIPTION
Issue addressed:
- #143 show state log in editor
- #159 state changes are all done via the state api now
- #307 remove reactivate, add unlock

It moves the withdrawn button to the button into the nav bar at the bottom.
There is quite a bit of ui changes that could still be done, but the PR is quite big as is. 