### PR TITLE
Fix create conference missing short error

### DIFF
--- a/app/models/Conference.scala
+++ b/app/models/Conference.scala
@@ -31,7 +31,7 @@ class Conference extends Model with Owned {
   @Column(nullable = false)
   var name: String = _
 
-  @Column(unique = true)
+  @Column(nullable = false, unique = true)
   var short: String = _
   var conferenceGroup: String = _
   var cite: String = _

--- a/test/controller/ConferenceCtrlTest.scala
+++ b/test/controller/ConferenceCtrlTest.scala
@@ -26,17 +26,37 @@ class ConferenceCtrlTest extends BaseCtrlTest {
 
   @Test
   def testCreate(): Unit = {
-    val body = formatter.writes(assets.conferences(0)).as[JsObject] - "uuid" - "abstracts" - "short"
 
-    val createUnauth = FakeRequest(POST, "/api/conferences").withHeaders(
-      ("Content-Type", "application/json")
-    ).withJsonBody(body)
+    val newShort = assets.conferences(0).short + "01"
+    val body = formatter.writes(assets.conferences(0))
+                  .as[JsObject] - "uuid" - "abstracts" ++ Json.obj("short" -> newShort)
+
+    val createUnauth = FakeRequest(POST, "/api/conferences")
+                        .withHeaders(("Content-Type", "application/json"))
+                        .withJsonBody(body)
     val failed = route(ConferenceCtrlTest.app, createUnauth).get
     assert(status(failed) == UNAUTHORIZED)
 
     val createAuth = createUnauth.withCookies(cookie)
     val created = route(ConferenceCtrlTest.app, createAuth).get
     assert(status(created) == CREATED)
+
+    val newName = assets.conferences(0).name + "01"
+    val bodyShortNull = formatter.writes(assets.conferences(0))
+                          .as[JsObject] - "uuid" - "abstracts" - "short" ++ Json.obj("name" -> newName)
+    val reqShortNull = FakeRequest(POST, "/api/conferences")
+                        .withHeaders(("Content-Type", "application/json"))
+                        .withJsonBody(bodyShortNull)
+                        .withCookies(cookie)
+    val respShortNull = routeWithErrors(ConferenceCtrlTest.app, reqShortNull).get
+    assert(status(respShortNull) == INTERNAL_SERVER_ERROR)
+
+    val shortNullMessage = contentAsJson(respShortNull)
+      .asInstanceOf[JsObject]
+      .fields.filter(f => f._1 == "message")
+      .head._2.toString()
+    assert(shortNullMessage.contains("NULL not allowed for column \\\"SHORT\\\""))
+
   }
 
   @Test


### PR DESCRIPTION
Saving a conference without a short description lead to an internal server error at the main page.

- Changed Conference short model column to not null.
- Added a create conference test without name.
- Added a create conference test without short.

This pull request closes Issue #330.