### PR TITLE
Use baseUrl from env (GCA_BASEURL), if available

### DIFF
--- a/app/utils/RoutesResolver.scala
+++ b/app/utils/RoutesResolver.scala
@@ -4,7 +4,7 @@ import java.net.URL
 
 class RoutesResolver {
   lazy val conf = play.api.Play.current.configuration
-  lazy val baseUrl = conf.getString("baseurl").getOrElse("http://localhost:9000")
+  lazy val baseUrl = sys.env.get("GCA_BASEURL").orElse(conf.getString("baseurl")).getOrElse("http://localhost:9000")
 
   /**
    * Builds an URL to the related abstracts from a given object ID.


### PR DESCRIPTION
Makes it possible to use the docker container with an different address then localhost.