### PR TITLE
[docker] Provide config from container outside

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,15 +21,21 @@ ADD project/build.properties /srv/gca/project/
 ADD public /srv/gca/public
 ADD test /srv/gca/test
 ADD build.sbt /srv/gca/
+ADD startup.sh /srv/gca
 
 RUN mkdir -p /srv/gca/db
 RUN echo "db.default.url=\"jdbc:h2:/srv/gca/db/gca-web\"" >> /srv/gca/conf/application.dev.conf
 
 # test and stage
 WORKDIR /srv/gca
+# Required to get dependencies before running the startup script.
 RUN activator test stage
 
 VOLUME ["/srv/gca/db"]
+VOLUME ["/srv/gca/conf"]
 
 EXPOSE 9000
-ENTRYPOINT ["target/universal/stage/bin/gca-web"]
+ENTRYPOINT ["/bin/bash", "startup.sh"]
+
+# Previous entrypoint using the staged binary
+#ENTRYPOINT ["target/universal/stage/bin/gca-web"]

--- a/startup.sh
+++ b/startup.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# Use tests to set up a database in a test environment
+activator test stage
+activator start
+


### PR DESCRIPTION
The changes to the docker file including the added entry point script enable providing a config file from outside the container.