### PR TITLE
Favourite Abstracts

### DIFF
--- a/app/assets/javascripts/abstract-list.js
+++ b/app/assets/javascripts/abstract-list.js
@@ -7,14 +7,14 @@ require(["lib/models", "lib/tools", "knockout", "sammy", "lib/offline"], functio
      * AbstractList view model.
      *
      *
-     * @param confId
+     * @param confId, loggedIn
      * @returns {AbstractListViewModel}
      * @constructor
      */
-    function AbstractListViewModel(confId) {
+    function AbstractListViewModel(confId, loggedIn) {
 
         if (! (this instanceof AbstractListViewModel)) {
-            return new AbstractListViewModel(confId);
+            return new AbstractListViewModel(confId, loggedIn);
         }
 
         var self = this;
@@ -23,6 +23,7 @@ require(["lib/models", "lib/tools", "knockout", "sammy", "lib/offline"], functio
         self.conference = ko.observable();
         self.abstracts = ko.observableArray(null);
         self.selectedAbstract = ko.observable(null);
+        self.isFavouriteAbstract = ko.observable(false);
         self.groups = ko.observableArray(null);
         self.error = ko.observable(false);
 
@@ -96,7 +97,21 @@ require(["lib/models", "lib/tools", "knockout", "sammy", "lib/offline"], functio
             }
             self.selectedAbstract(abstract);
             document.title = abstract.title; //FIXME add conference
+            //if user is not logged in
+            if(loggedIn.indexOf('true')>=0){
+                self.isFavourite(abstract);
+            }
             MathJax.Hub.Queue(["Typeset",MathJax.Hub]); //re-render equations
+        };
+
+        self.favourAbstract = function(abstract) {
+            var absUrl = "/api/abstracts/" + abstract.uuid + "/addfavuser";
+            return absUrl;
+        };
+
+        self.disfavourAbstract = function(abstract) {
+            var absUrl = "/api/abstracts/" + abstract.uuid + "/removefavuser";
+            return absUrl;
         };
 
         self.showAbstractByUUID = function(uuid) {
@@ -232,6 +247,18 @@ require(["lib/models", "lib/tools", "knockout", "sammy", "lib/offline"], functio
             return self.neighbours[uuid].prev;
         };
 
+        self.isFavourite = function(abstract) {
+            var uuid = abstract.uuid;
+            var favUsersUrl = "/api/user/self/abstract/" + uuid + "/isfavuser";
+            $.get(favUsersUrl,onFavUserData).fail(self.ioFailHandler);
+            function onFavUserData(isFavUser) {
+                console.log('IsFavUser '+ isFavUser);
+                var IFUBool = (isFavUser == 'true');
+                console.log('IsFavUser IFUBool '+ IFUBool);
+                self.isFavouriteAbstract(IFUBool);
+            }
+        };
+
         //Data IO
         self.ioFailHandler = function(jqxhr, textStatus, error) {
             var err = textStatus + ", " + error;
@@ -310,9 +337,9 @@ require(["lib/models", "lib/tools", "knockout", "sammy", "lib/offline"], functio
 
         var data = tools.hiddenData();
 
-        console.log(data.conferenceUuid);
+        console.log(data.conferenceUuid,data.loggedIn);
 
-        window.abstractList = AbstractListViewModel(data.conferenceUuid);
+        window.abstractList = AbstractListViewModel(data.conferenceUuid,data.loggedIn);
         window.abstractList.init();
     });
 

--- a/app/assets/javascripts/abstracts-favourite.js
+++ b/app/assets/javascripts/abstracts-favourite.js
@@ -1,0 +1,143 @@
+require(["main"], function () {
+    require(["lib/models", "lib/tools", "knockout", "sammy"], function (models, tools, ko, Sammy) {
+        "use strict";
+
+
+        /**
+         * AbstractList view model.
+         *
+         *
+         * @param confId
+         * @returns {AbstractListViewModel}
+         * @constructor
+         */
+        function FavouriteAbstractsViewModel() {
+
+            if (!(this instanceof FavouriteAbstractsViewModel)) {
+                return new FavouriteAbstractsViewModel();
+            }
+
+            var self = this;
+
+            self.conferences = ko.observableArray(null);
+            self.isLoading = ko.observable(true);
+            self.noFavouriteAbstracts = ko.observable(false);
+            self.error = ko.observable(false);
+
+
+            self.setError = function (level, text) {
+                self.error({message: text, level: 'alert-' + level});
+                self.isLoading(false);
+            };
+
+
+            self.init = function () {
+                ko.applyBindings(window.dashboard);
+            };
+
+            self.makeAbstractLink = function (abstract, conference) {
+                return "/myabstracts/" + abstract.uuid + "/edit";
+            };
+
+
+            //Data IO
+            self.ioFailHandler = function (jqxhr, textStatus, error) {
+                if(find(jqxhr.responseText,"No favourite abstracts") != -1){
+                    self.noFavouriteAbstracts(true);
+                    self.isLoading(false);
+                }else {
+                    var err = textStatus + ", " + error + ", " + jqxhr.responseText;
+                    console.log("Request Failed: " + err);
+                    self.setError("danger", "Error while loading data [" + err + "]!");
+                }
+            };
+
+            self.ensureDataAndThen = function (doAfter) {
+                console.log("ensureDataAndThen::");
+
+                //now load the data from the server
+                var confURL = "/api/user/self/conffavouriteabstracts";
+                $.getJSON(confURL, onConferenceData).fail(self.ioFailHandler);
+
+                //conference data
+                function onConferenceData(confObj) {
+                    console.log("+ onConferenceData")
+                    var confs = models.Conference.fromArray(confObj);
+                    if (confs !== null) {
+                        confs.forEach(function (current) {
+                            current.abstracts = ko.observableArray(null);
+                            console.log(current.short);
+                        });
+
+                    }
+
+                    self.conferences(confs);
+
+                    if (confs !== null) {
+                        confs.forEach(function (current) {
+                            //needs some fix to include "conferences/" + current.uuid
+                            var absUrl = "/api/user/self/conferences/" + current.uuid + "/favouriteabstracts";
+                            self.currConfShort = current.short;
+                            $.getJSON(absUrl, onAbstractData(current)).fail(self.ioFailHandler);
+                        });
+                    }
+
+                    doAfter();
+                }
+
+                function onAbstractData(currentConf) {
+                    return function (abstractList) {
+                        var absList = models.Abstract.fromArray(abstractList);
+
+                        absList.forEach(function (abstr) {
+                            abstr.createLink = ko.computed(function () {
+                                return {
+                                    absLink: "/conference/" + self.currConfShort + "/abstracts#/uuid/" + abstr.uuid
+                                };
+                            });
+                            /*abstr.viewEditCtx = ko.computed(function () {
+                                var confIsOpen = currentConf.isOpen;
+                                var canEdit = abstr.state == "InRevision" ||
+                                    (confIsOpen && (abstr.state == "InPreparation" ||
+                                        abstr.state == "Submitted" ||
+                                        abstr.state == "Withdrawn"));
+
+                                return {
+                                    link: canEdit ? "/myabstracts/" + abstr.uuid + "/edit" : "/abstracts/" + abstr.uuid,
+                                    label: canEdit ? "Edit" : "View",
+                                    btn: canEdit ? "btn-danger" : "btn-primary"
+                                };
+                            });*/
+                        });
+
+                        currentConf.abstracts(absList);
+                    }
+                }
+            };
+
+
+            // client-side routes
+            Sammy(function () {
+
+                this.get('#/', function () {
+                    console.log('Sammy::get::');
+                    self.ensureDataAndThen(function () {
+                        self.isLoading(false);
+                    });
+                });
+
+            }).run('#/');
+
+        }
+
+        $(document).ready(function () {
+
+            var data = tools.hiddenData();
+
+
+            window.dashboard = FavouriteAbstractsViewModel();
+            window.dashboard.init();
+        });
+
+    });
+});

--- a/app/assets/javascripts/locations.js
+++ b/app/assets/javascripts/locations.js
@@ -73,36 +73,41 @@ require(["lib/models", "lib/tools", "lib/leaflet/leaflet", "lib/msg", "lib/astat
 
                                 for(var j=0; j<geojson[i].floorplans.length; j++) {
 
-                                    $('#floorplans-wrap').append('<div id="floorplan-div-' + i + + j + '" class="floorplan-divs" style="margin-bottom: 1em;"></div>');
-
                                     //create image in order to get actual image dimensions cross browser
-                                    var img = $("<img>").attr("src", geojson[i].floorplans[j]);
-                                    var nw = img.prop('naturalWidth');
-                                    var nh = img.prop('naturalHeight');
+                                    var img = new Image();
+                                    img.src = geojson[i].floorplans[j];
+                                    img.onload = handleLoad;
 
-                                    var floor = L.map('floorplan-div-' + i + j, {
-                                        crs: L.CRS.Simple,
-                                        minZoom: 0
-                                    });
+                                    function handleLoad(response) {
 
-                                    if(nh>nw){
-                                        $('#floorplan-div-'+i+j).height($('#floorplan-div-'+i+j).width());
-                                        $('#floorplan-div-'+i+j).width(nw/nh*$('#floorplan-div-'+i+j).height());
-                                    }else{
-                                        $('#floorplan-div-'+i+j).height(nh/nw*$('#floorplan-div-'+i+j).width());
+                                        $('#floorplans-wrap').append('<div id="floorplan-div-' + i + + j + '" class="floorplan-divs" style="margin-bottom: 1em;"></div>');
+
+                                        // Get accurate measurements from that.
+                                        var nw = img.width;
+                                        var nh = img.height;
+
+                                        console.log(nw+' '+nh+' '+img.src);
+                                        var floor = L.map('floorplan-div-' + i + j, {
+                                            crs: L.CRS.Simple,
+                                            minZoom: 0
+                                        });
+
+                                        if(nh>nw){
+                                            $('#floorplan-div-'+i+j).height($('#floorplan-div-'+i+j).width());
+                                            $('#floorplan-div-'+i+j).width(nw/nh*$('#floorplan-div-'+i+j).height());
+                                        }else{
+                                            $('#floorplan-div-'+i+j).height(nh/nw*$('#floorplan-div-'+i+j).width());
+                                        }
+
+                                        var bounds  = [[0, 0], [$('#floorplan-div-'+i+j).height(), $('#floorplan-div-'+i+j).width()]];
+                                        var image = L.imageOverlay(img.src, bounds).addTo(floor);
+                                        floor.fitBounds(bounds);
                                     }
-
-                                    var bounds  = [[0, 0], [$('#floorplan-div-'+i+j).height(), $('#floorplan-div-'+i+j).width()]];
-                                    var image = L.imageOverlay(geojson[i].floorplans[j], bounds).addTo(floor);
-                                    floor.fitBounds(bounds);
                                     //possible to incorporate rooms with coordinates just as above,
                                     //just be sure to use right coordinate system (cf. leaflet page)
                                     //and mapping probably needed for room number vs. location
                                 }
                             }
-                        }
-                        if($('.floorplan-divs').length == 0){
-                            $('#floorplans-wrap').append('<p>No floorplans available for this conference.</p>');
                         }
                     }
                     //add addresses as text

--- a/app/assets/stylesheets/layout.less
+++ b/app/assets/stylesheets/layout.less
@@ -159,6 +159,18 @@ body {
     }
   }
 
+  .favour{
+    color: white !important;
+    background-color: gold !important;
+    border-radius: 4px;
+  }
+  .disfavour{
+    color: white;
+    background-color: darkred;
+    border-radius: 4px;
+    border: none;
+  }
+
   .abstract-text {
     .std-gap;
     font-family: @font-family-serif;

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -73,6 +73,10 @@ class Application(implicit val env: Environment[Login, CachedCookieAuthenticator
     Ok(views.html.dashboard.user(request.identity.account))
   }
 
+  def abstractsFavourite = SecuredAction { implicit request =>
+    Ok(views.html.dashboard.favouriteabstracts(request.identity.account))
+  }
+
   def abstractsPending = SecuredAction { implicit request =>
     val conference = conferenceService.list()(0)
 

--- a/app/controllers/api/Abstracts.scala
+++ b/app/controllers/api/Abstracts.scala
@@ -103,6 +103,17 @@ extends Silhouette[Login, CachedCookieAuthenticator] {
     resultWithETag(ownAbstracts)
   }
 
+  /**
+    * List all favourite abstracts for a given user.
+    *
+    * replace Own by Favourite
+    *
+    * @return All (accessible) abstracts for a given user.
+    */
+  def listFavByAccount(id: String) = SecuredAction { implicit request =>
+    val favAbstracts = abstractService.listFavourite(request.identity.account)
+    resultWithETag(favAbstracts)
+  }
 
   /**
    * List all abstracts for a given conference and a given user
@@ -111,11 +122,22 @@ extends Silhouette[Login, CachedCookieAuthenticator] {
    */
   def listOwn(conferenceId: String) = SecuredAction { implicit request =>
 
-  val conference = conferenceService.get(conferenceId)
-  val abstracts = abstractService.listOwn(conference, request.identity.account)
+    val conference = conferenceService.get(conferenceId)
+    val abstracts = abstractService.listOwn(conference, request.identity.account)
 
-  resultWithETag(abstracts)
-}
+    resultWithETag(abstracts)
+  }
+
+  /**
+    * List all favourite abstracts for a given conference and a given user
+    *
+    * @return All (accessible) favourite abstracts for a given user.
+    */
+  def listFavByConf(conferenceId: String) = SecuredAction { implicit request =>
+    val conference = conferenceService.get(conferenceId)
+    val abstracts = abstractService.listFavourite(conference, request.identity.account)
+    resultWithETag(abstracts)
+  }
 
   /**
    * An abstract info by id.

--- a/app/controllers/api/Abstracts.scala
+++ b/app/controllers/api/Abstracts.scala
@@ -241,6 +241,50 @@ extends Silhouette[Login, CachedCookieAuthenticator] {
     ))
   }
 
+  /**
+    * Get favourite users of the abstract.
+    *
+    * @return a list of updated permissions (accounts) as JSON
+    */
+  def favouriteUsers(id: String) = SecuredAction { implicit request =>
+    val abstr = abstractService.getFav(id, request.identity.account)
+    val favUsers = abstractService.getFavouriteUsers(abstr, request.identity.account)
+    Ok(JsArray(
+      for (acc <- favUsers) yield accountFormat.writes(acc)
+    ))
+  }
+  /**
+    * Check, whether current user is has the abstract as a favourite.
+    *
+    * @return a list of updated permissions (accounts) as JSON
+    */
+  def isFavouriteUser(id: String) = SecuredAction { implicit request =>
+    val abstr = abstractService.get(id)
+    Ok(abstr.favUsers.contains(request.identity.account).toString)
+  }
+  /**
+    * Add favourite users of the abstract.
+    *
+    * @return a list of updated permissions (accounts) as JSON
+    */
+  def addFavUser(id: String) = SecuredAction { implicit request =>
+    Logger.debug(s"Liking abstract with uuid: [$id]")
+    val abstr = abstractService.get(id)
+    abstractService.addFavUser(abstr, request.identity.account)
+    Ok(views.html.dashboard.favouriteabstracts(request.identity.account))
+  }
+  /**
+    * Remove favourite users of the abstract.
+    *
+    * @return a list of updated permissions (accounts) as JSON
+    */
+  def removeFavUser(id: String) = SecuredAction { implicit request =>
+    Logger.debug(s"Disliking abstract with uuid: [$id]")
+    val abstr = abstractService.get(id)
+    abstractService.removeFavUser(abstr, request.identity.account)
+    Ok(views.html.dashboard.favouriteabstracts(request.identity.account))
+  }
+
   def listState(id: String) = SecuredAction { implicit request =>
     implicit val logWrites = new StateLogWrites()
 

--- a/app/controllers/api/Conferences.scala
+++ b/app/controllers/api/Conferences.scala
@@ -78,6 +78,21 @@ class Conferences(implicit val env: Environment[Login, CachedCookieAuthenticator
   }
 
   /**
+    * List all available conferences for which the current user is an owner
+    * of at least an abstract
+    *
+    * @return Ok with all conferences publicly available.
+    */
+  def listWithFavAbstracts =  SecuredAction { implicit request =>
+    val conferences = conferenceService.listWithFavouriteAbstractsOfAccount(request.identity.account)
+    if (conferences.length==0) {
+      BadRequest("No favourite abstracts")
+    } else {
+      resultWithETag(conferences)
+    }
+  }
+
+  /**
    * A conference info by id.
    *
    * @param id The id of the conference.

--- a/app/models/Abstract.scala
+++ b/app/models/Abstract.scala
@@ -58,6 +58,9 @@ class Abstract extends Model with Owned with Tagged {
   @ManyToMany
   @JoinTable(name = "abstract_owners")
   var owners:  JSet[Account] = new JTreeSet[Account]()
+  @ManyToMany
+  @JoinTable(name = "abstract_favUsers")
+  var favUsers:  JSet[Account] = new JTreeSet[Account]()
   @OneToMany(mappedBy = "abstr", cascade = Array(CascadeType.ALL), orphanRemoval = true)
   var authors: JSet[Author] = new JTreeSet[Author]()
   @OneToMany(mappedBy = "abstr", cascade = Array(CascadeType.ALL), orphanRemoval = true)
@@ -95,6 +98,7 @@ object Abstract {
             conference: Option[Conference] = None,
             figures: Seq[Figure] = Nil,
             owners:  Seq[Account] = Nil,
+            favUsers:  Seq[Account] = Nil,
             authors: Seq[Author] = Nil,
             affiliations: Seq[Affiliation] = Nil,
             references: Seq[Reference] = Nil,
@@ -117,6 +121,7 @@ object Abstract {
     abstr.conference  = unwrapRef(conference)
     abstr.figures      = toJSet(figures)
     abstr.owners      = toJSet(owners)
+    abstr.favUsers      = toJSet(owners)
     abstr.authors     = toJSet(authors)
     abstr.affiliations = toJSet(affiliations)
     abstr.references  = toJSet(references)

--- a/app/models/Account.scala
+++ b/app/models/Account.scala
@@ -40,6 +40,11 @@ class Account extends Model {
 
   @ManyToMany(mappedBy = "owners")
   var abstracts: JSet[Abstract] = new JTreeSet[Abstract]()
+  /**
+    * here ManyToMany, to get number of likes/author access to liking persons
+    */
+  @ManyToMany(mappedBy = "favUsers")
+  var favAbstracts: JSet[Abstract] = new JTreeSet[Abstract]()
   @ManyToMany(mappedBy = "owners")
   var conferences: JSet[Conference] = new JTreeSet[Conference]()
 
@@ -58,6 +63,7 @@ object Account {
   def apply(uuid: Option[String],
             mail: Option[String],
             abstracts: Seq[Abstract] = Nil,
+            favAbstracts: Seq[Abstract] = Nil,
             conferences: Seq[Conference] = Nil) : Account = {
 
     val account = new Account()
@@ -67,6 +73,7 @@ object Account {
 
     account.conferences = toJSet(conferences)
     account.abstracts   = toJSet(abstracts)
+    account.favAbstracts   = toJSet(favAbstracts)
 
     account
   }
@@ -90,6 +97,7 @@ object Account {
 
     account.conferences = toJSet(Nil)
     account.abstracts   = toJSet(Nil)
+    account.favAbstracts   = toJSet(Nil)
 
     account
   }

--- a/app/service/AbstractService.scala
+++ b/app/service/AbstractService.scala
@@ -128,6 +128,50 @@ class AbstractService(figPath: String) extends PermissionsBase {
   }
 
   /**
+    * List all published and unpublished favourite abstracts that belong to an account.
+    *
+    * @param account The account for which to list the abstracts.
+    * @return All abstracts that are favourites of the current account.
+    */
+  def listFavourite(account: Account) : Seq[Abstract] = {
+    query { em =>
+      val queryStr =
+        """SELECT DISTINCT a FROM Abstract a
+           LEFT JOIN FETCH a.owners f
+           LEFT JOIN FETCH a.authors
+           LEFT JOIN FETCH a.affiliations
+           LEFT JOIN FETCH a.conference
+           LEFT JOIN FETCH a.figures
+           LEFT JOIN FETCH a.references
+           WHERE f.uuid = :uuid
+          ORDER BY a.sortId, a.title"""
+      val query: TypedQuery[Abstract] = em.createQuery(queryStr, classOf[Abstract])
+      query.setParameter("uuid", account.uuid)
+      asScalaBuffer(query.getResultList)
+    }
+  }
+
+  def listFavourite(conference: Conference, account: Account) : Seq[Abstract] = {
+    query { em =>
+      val queryStr =
+        """SELECT DISTINCT a FROM Abstract a
+           LEFT JOIN FETCH a.owners f
+           LEFT JOIN FETCH a.authors
+           LEFT JOIN FETCH a.affiliations
+           LEFT JOIN FETCH a.conference c
+           LEFT JOIN FETCH a.figures
+           LEFT JOIN FETCH a.references
+           WHERE c.uuid = :ConfUuid AND f.uuid = :FavUserUuid
+           ORDER BY a.sortId, a.title"""
+      val query: TypedQuery[Abstract] = em.createQuery(queryStr, classOf[Abstract])
+      query.setParameter("ConfUuid", conference.uuid)
+      query.setParameter("FavUserUuid", account.uuid)
+      asScalaBuffer(query.getResultList)
+    }
+  }
+
+
+  /**
    * Return a published (= Accepted && Conference.isPublished) abstract by id.
    *
    * @param id The id of the abstract.

--- a/app/service/AbstractService.scala
+++ b/app/service/AbstractService.scala
@@ -137,7 +137,8 @@ class AbstractService(figPath: String) extends PermissionsBase {
     query { em =>
       val queryStr =
         """SELECT DISTINCT a FROM Abstract a
-           LEFT JOIN FETCH a.owners f
+           LEFT JOIN FETCH a.owners
+           LEFT JOIN FETCH a.favUsers f
            LEFT JOIN FETCH a.authors
            LEFT JOIN FETCH a.affiliations
            LEFT JOIN FETCH a.conference
@@ -155,7 +156,8 @@ class AbstractService(figPath: String) extends PermissionsBase {
     query { em =>
       val queryStr =
         """SELECT DISTINCT a FROM Abstract a
-           LEFT JOIN FETCH a.owners f
+           LEFT JOIN FETCH a.owners
+           LEFT JOIN FETCH a.favUsers f
            LEFT JOIN FETCH a.authors
            LEFT JOIN FETCH a.affiliations
            LEFT JOIN FETCH a.conference c

--- a/app/service/AbstractService.scala
+++ b/app/service/AbstractService.scala
@@ -173,6 +173,20 @@ class AbstractService(figPath: String) extends PermissionsBase {
   }
 
 
+  def isFavourite(conference: Conference, account: Account) : Seq[Abstract] = {
+    query { em =>
+      val queryStr =
+        """SELECT DISTINCT a FROM Abstract a
+           LEFT JOIN FETCH a.favUsers f
+           WHERE a.uuid = :AbstrUuid AND f.uuid = :FavUserUuid
+           ORDER BY a.sortId, a.title"""
+      val query: TypedQuery[Abstract] = em.createQuery(queryStr, classOf[Abstract])
+      query.setParameter("ConfUuid", conference.uuid)
+      query.setParameter("FavUserUuid", account.uuid)
+      asScalaBuffer(query.getResultList)
+    }
+  }
+
   /**
    * Return a published (= Accepted && Conference.isPublished) abstract by id.
    *
@@ -242,6 +256,62 @@ class AbstractService(figPath: String) extends PermissionsBase {
         throw new IllegalAccessException("No permissions for abstract with uuid = " + abstr.uuid)
 
       abstr
+    }
+  }
+
+  /**
+    * Return an abstract with a certain id, that is accessible for an account.
+    * The abstract doesnt need to be published if the account has appropriate
+    * access.
+    *
+    * @param id      The id of the abstract.
+    * @param account The account who wants to request the abstract.
+    * @return The abstract with the specified id.
+    * @throws EntityNotFoundException If the account does not exist
+    * @throws IllegalAccessException if not accessible
+    * @throws NoResultException If was not found
+    */
+  def getFav(id: String, account: Account) : Abstract = {
+    query { em =>
+      val queryStr =
+        """SELECT DISTINCT a FROM Abstract a
+           LEFT JOIN FETCH a.owners
+           LEFT JOIN FETCH a.favUsers
+           LEFT JOIN FETCH a.authors
+           LEFT JOIN FETCH a.affiliations
+           LEFT JOIN FETCH a.conference
+           LEFT JOIN FETCH a.figures
+           LEFT JOIN FETCH a.references
+           WHERE a.uuid = :uuid"""
+      // this apparently useless query is needed to avoid strange caching behaviour related to #285
+      val queryUserStr =  """SELECT acc FROM Account acc LEFT JOIN acc.favAbstracts a WHERE a.uuid = :uuid"""
+      em.createQuery(queryUserStr, classOf[Account])
+        .setParameter("uuid", id)
+        .getResultList
+      val accountChecked = em.find(classOf[Account], account.uuid)
+      if (accountChecked == null)
+        throw new EntityNotFoundException("Unable to find account with uuid = " + account.uuid)
+      val query: TypedQuery[Abstract] = em.createQuery(queryStr, classOf[Abstract])
+      query.setParameter("uuid", id)
+      val abstr = query.getSingleResult
+      abstr
+    }
+  }
+  /**
+    * Get permissions of an existing object.
+    * This is only permitted if the account owns the object.
+    *
+    * @param obj        object with certain permissions.
+    * @param account    The account who wants to access permissions.
+    */
+  def getFavouriteUsers(obj: Abstract, account: Account) : List[Account] = {
+    transaction { (em, tx) =>
+      if (obj.uuid == null)
+        throw new IllegalArgumentException("Unable to update an object without uuid")
+      val objChecked = em.find(obj.getClass, obj.uuid)
+      if (objChecked == null)
+        throw new EntityNotFoundException("Unable to find conference with uuid = " + obj.uuid)
+      objChecked.favUsers.toList
     }
   }
 
@@ -354,6 +424,39 @@ class AbstractService(figPath: String) extends PermissionsBase {
 
     getOwn(abstrUpdated.uuid, account)
   }
+
+
+  /**
+    * Add a favourite user from an abstract.
+    *
+    * @param abstr   The Abstract to update.
+    * @param account The account who wants to perform the update.
+    * @return The updated and persisted abstract.
+    */
+  def addFavUser(abstr : Abstract, account: Account) : Abstract = {
+    val abstrUpdated = transaction { (em, tx) =>
+      abstr.favUsers.add(account)
+      val merged = em.merge(abstr)
+      merged
+    }
+    get(abstrUpdated.uuid)
+  }
+  /**
+    * Remove a favourite user from an abstract.
+    *
+    * @param abstr   The Abstract to update.
+    * @param account The account who wants to perform the update.
+    * @return The updated and persisted abstract.
+    */
+  def removeFavUser(abstr : Abstract, account: Account) : Abstract = {
+    val abstrUpdated = transaction { (em, tx) =>
+      abstr.favUsers.remove(account)
+      val merged = em.merge(abstr)
+      merged
+    }
+    get(abstrUpdated.uuid)
+  }
+
 
   /**
    * Delete an abstract.

--- a/app/service/ConferenceService.scala
+++ b/app/service/ConferenceService.scala
@@ -108,6 +108,22 @@ class ConferenceService() extends PermissionsBase {
     }
   }
 
+
+  def listWithFavouriteAbstractsOfAccount(account: Account) : Seq[Conference] = {
+    query { em =>
+      val queryStr =
+        """SELECT DISTINCT c FROM Conference c
+           INNER JOIN c.abstracts a
+           INNER JOIN a.owners af
+           WHERE af.uuid = :uuid
+           ORDER BY c.startDate DESC"""
+      val query : TypedQuery[Conference] = em.createQuery(queryStr, classOf[Conference])
+      query.setParameter("uuid", account.uuid)
+      asScalaBuffer(query.getResultList)
+    }
+  }
+
+
   /**
    * Get a conference specified by its id.
    *

--- a/app/utils/RoutesResolver.scala
+++ b/app/utils/RoutesResolver.scala
@@ -18,6 +18,17 @@ class RoutesResolver {
   }
 
   /**
+    * Builds an URL to the related favourite abstracts from a given object ID.
+    *
+    * @param id an ID of a Conference object to insert into the URL
+    *
+    * @return URL for related abstracts, like "/conferences/HNOPSADMHV/favouriteabstracts"
+    */
+  def favUsersUrl(id: String) = {
+    new URL(baseUrl + s"/api/abstracts/$id/favusers")
+  }
+
+  /**
    * Builds an URL to the related abstracts from a given object ID.
    *
    * @param id an ID of a Conference object to insert into the URL
@@ -38,6 +49,18 @@ class RoutesResolver {
   def allAbstractsUrl(id: String) = {
     new URL(baseUrl + s"/api/conferences/$id/allAbstracts")
   }
+
+  /**
+    * Builds an URL to the related abstracts from a given object ID.
+    *
+    * @param id an ID of a User object to insert into the URL
+    *
+    * @return URL for related abstracts, like "/api/user/HNOPSADMHV/favouriteabstracts"
+    */
+  def favAbstractsUrl(id: String) = {
+    new URL(baseUrl + s"/api/user/$id/favouriteabstracts")
+  }
+
 
   /**
    * Builds an URL to figure file.

--- a/app/utils/serializer.scala
+++ b/app/utils/serializer.scala
@@ -170,7 +170,8 @@ package object serializer {
         "mail" -> account.mail,
         "fullName" -> account.fullName,
         "ctime" -> account.ctime,
-        "abstracts" -> routesResolver.abstractsUrl(account.uuid)
+        "abstracts" -> routesResolver.abstractsUrl(account.uuid),
+        "favAbstracts" -> routesResolver.favAbstractsUrl(account.uuid)
       )
     }
   }
@@ -315,7 +316,7 @@ package object serializer {
       (__ \ "affiliations").read[List[Affiliation]].addPosition and
       (__ \ "references").read[List[Reference]].addPosition and
         (__ \ "abstrTypes").read[List[AbstractGroup]]
-    )(Abstract(_, _, _, _, _, _, _, _, _, _, _, None, Nil, Nil, _, _, _,_)).reads(json)
+    )(Abstract(_, _, _, _, _, _, _, _, _, _, _, None, Nil, Nil, Nil, _, _, _,_)).reads(json)
 
     override def writes(a: Abstract): JsValue = {
 
@@ -335,6 +336,7 @@ package object serializer {
         "conference" -> routesResolver.conferenceUrl(a.conference.uuid),
         "figures" -> asScalaSet(a.figures).toSeq.sorted[Model],
         "owners" -> routesResolver.ownersUrl(a.uuid),
+        "favUsers" -> routesResolver.favUsersUrl(a.uuid),
         "authors" -> asScalaSet(a.authors).toSeq.sorted[Model],
         "affiliations" -> asScalaSet(a.affiliations).toSeq.sorted[Model],
         "references" -> asScalaSet(a.references).toSeq.sorted[Model],

--- a/app/views/abstractlist.scala.html
+++ b/app/views/abstractlist.scala.html
@@ -4,6 +4,7 @@
 
     <div class="hidden-data">
         <div id="conference-uuid">@conference.uuid</div>
+        <div id="logged-in">@if(account.isDefined) {"true"} else {"false"}</div>
     </div>
 
     <script data-main="@routes.Assets.at("javascripts/abstract-list.js")"
@@ -72,6 +73,16 @@
                <span data-bind="html: formatSortId($parent.sortId)"></span>
                <!-- /ko -->
             </li>
+
+            @if(account.isDefined) {
+                <li data-bind="visible: !$root.isFavouriteAbstract()">
+                    <a class="favour" data-bind="attr:{href : $root.favourAbstract($data)}">&#9733</a>
+                </li>
+                <li data-bind="visible: $root.isFavouriteAbstract">
+                    <a class="disfavour" data-bind="attr:{href : $root.disfavourAbstract($data)}">&#9733</a>
+                </li>
+            }
+
             <li class="next" data-bind="css: { disabled: $parent.nextAbstract($data) == null }">
                 <a data-bind="attr: {href : $parent.nextAbstract($data)}">Next &rarr;</a>
             </li>

--- a/app/views/dashboard/favouriteabstracts.scala.html
+++ b/app/views/dashboard/favouriteabstracts.scala.html
@@ -1,0 +1,64 @@
+@(account: Account)
+
+@template(Some(account), None, "Favourite Abstracts") {
+
+    <div class="hidden-data">
+        <div id="conference-uuid">@account.uuid</div>
+    </div>
+
+    <script data-main="@routes.Assets.at("javascripts/abstracts-favourite.js")"
+    src="@routes.Assets.at("javascripts/require.js")"></script>
+
+
+        <!-- Loading box -->
+    <div data-bind="if: isLoading">
+        <div class="alert alert-info fade in out">
+            <h4>Loading data</h4>
+            <p>Please wait...</p>
+        </div>
+    </div>
+
+        <!-- If no Favourites -->
+    <div data-bind="if: noFavouriteAbstracts">
+        <div class="alert alert-info fade in out">
+            <h4>You have no favourite abstracts yet. Click the star button shown for abstracts to add them.</h4>
+        </div>
+    </div>
+
+        <!-- Knockout !flickerbox  -->
+    <div style="display: none" data-bind="visible: true">
+
+            <!-- Error message box -->
+        <div data-bind="visible: error">
+                <!-- ko with: error -->
+            <div class="alert alert-warning fade in alert-dismissable" data-bind="css: level">
+                <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
+                <strong data-bind="html: message"></strong>
+            </div>
+                <!-- /ko -->
+        </div>
+
+
+        <div data-bind="foreach: conferences">
+            <div class="panel panel-default">
+                <div class="panel-heading" >
+                    <a data-bind="attr: { href: link }">
+                        <h4 class="panel-title" data-bind="text: name"></h4>
+                    </a>
+                </div>
+                <div class="panel-body">
+                    <span data-bind="text: cite"></span>
+                </div>
+                <ul id="abstract-list" class="list-group" data-bind="foreach: abstracts">
+                    <a data-bind="attr: { href: createLink().absLink }">
+                        <li id="abstract-list-item" class="list-group-item abstract">
+                            <span data-bind="text: title"></span>
+                        </li>
+                    </a>
+                </ul>
+            </div>
+        </div>
+
+    </div>
+
+}

--- a/app/views/template.scala.html
+++ b/app/views/template.scala.html
@@ -146,6 +146,12 @@
                                 <a href="@routes.Application.abstractsPrivate()">My Abstracts</a>
                             </li>
                         }
+
+                        @account.map { acc =>
+                            <li class=@if(active.toLowerCase == "favouriteabstracts") {"active"} else {""}>
+                                <a href="@routes.Application.abstractsFavourite()">Favourite Abstracts</a>
+                            </li>
+                        }
                     }
 
                     @if(conference.isEmpty && active) {

--- a/conf/routes
+++ b/conf/routes
@@ -19,6 +19,7 @@ GET           /conference/:id/floorplans                      @controllers.Appli
 GET           /conference/:id/abstracts                       @controllers.Application.abstractsPublic(id: String)
 GET           /conference/:id/schedule                        @controllers.Application.schedule(id: String)
 GET           /myabstracts                                    @controllers.Application.abstractsPrivate
+GET           /favouriteabstracts                             @controllers.Application.abstractsFavourite
 GET           /myabstracts/:id/edit                           @controllers.Application.edit(id: String)
 GET           /submitted                                      @controllers.Application.abstractsPending
 
@@ -76,8 +77,11 @@ DELETE        /api/figures/:id                                @controllers.api.F
 GET           /api/users                                      @controllers.api.Accounts.accountsByEmail(email: String)
 GET           /api/user/list                                  @controllers.api.Accounts.listAccounts()
 GET           /api/user/:id/abstracts                         @controllers.api.Abstracts.listByAccount(id: String)
+GET           /api/user/:id/favouriteabstracts                @controllers.api.Abstracts.listFavByAccount(id: String)
 GET           /api/user/self/conferences/:id/abstracts        @controllers.api.Abstracts.listOwn(id: String)
+GET           /api/user/self/conferences/:id/favouriteabstracts        @controllers.api.Abstracts.listFavByConf(id: String)
 GET           /api/user/self/conferences                      @controllers.api.Conferences.listWithOwnAbstracts
+GET           /api/user/self/conffavouriteabstracts           @controllers.api.Conferences.listWithFavAbstracts
 
 
 # Auth -----------------------------------------------------------------------------------------------------------------

--- a/conf/routes
+++ b/conf/routes
@@ -61,6 +61,9 @@ POST          /api/abstracts/:id/figures                      @controllers.api.F
 GET           /api/abstracts/:id/figures                      @controllers.api.Figures.list(id: String)
 PUT           /api/abstracts/:id/owners                       @controllers.api.Abstracts.setPermissions(id: String)
 GET           /api/abstracts/:id/owners                       @controllers.api.Abstracts.getPermissions(id: String)
+GET           /api/abstracts/:id/favusers                     @controllers.api.Abstracts.favouriteUsers(id: String)
+GET           /api/abstracts/:id/addfavuser                   @controllers.api.Abstracts.addFavUser(id: String)
+GET           /api/abstracts/:id/removefavuser                @controllers.api.Abstracts.removeFavUser(id: String)
 GET           /api/abstracts/:id/stateLog                     @controllers.api.Abstracts.listState(id: String)
 PUT           /api/abstracts/:id/state                        @controllers.api.Abstracts.setState(id: String)
 
@@ -82,6 +85,7 @@ GET           /api/user/self/conferences/:id/abstracts        @controllers.api.A
 GET           /api/user/self/conferences/:id/favouriteabstracts        @controllers.api.Abstracts.listFavByConf(id: String)
 GET           /api/user/self/conferences                      @controllers.api.Conferences.listWithOwnAbstracts
 GET           /api/user/self/conffavouriteabstracts           @controllers.api.Conferences.listWithFavAbstracts
+GET           /api/user/self/abstract/:id/isfavuser           @controllers.api.Abstracts.isFavouriteUser(id: String)
 
 
 # Auth -----------------------------------------------------------------------------------------------------------------

--- a/test/service/Assets.scala
+++ b/test/service/Assets.scala
@@ -282,6 +282,8 @@ class Assets() {
         abstr.owners.add(alice)
         abstr.owners.add(bob)
 
+        abstr.favUsers.add(bob)
+
         abstr.authors.foreach { author =>
           author.abstr = abstr
         }

--- a/test/util/serializer/SerializerTest.scala
+++ b/test/util/serializer/SerializerTest.scala
@@ -26,7 +26,7 @@ class SerializerTest extends JUnitSuite {
   val sampleFigure: Figure = Figure(Option("someuuid"), Option("caption"))
   val sampleAbstract = Abstract(Option("someuuid"), Option("title"), Option("topic"),
       Option("text"), Option("doi"), Option("conflictOfInterest"), Option("acknowledgements"), Option(true), Option("reason"),
-        Some(0), Some(AbstractState.InPreparation), Option(sampleConference), Seq(sampleFigure), Nil, Seq(sampleAuthor),
+        Some(0), Some(AbstractState.InPreparation), Option(sampleConference), Seq(sampleFigure), Nil, Nil, Seq(sampleAuthor),
           Seq(sampleAffiliation), Seq(sampleReference))
 
   @Test


### PR DESCRIPTION
The favourite abstracts functionality. The three commits show three different parts:

The frontend functionality listing "favourite" abstracts still using the owners property.
The extension of the favUsers/favAbstracts properties.
The front+backend ability to like/dislike abstracts.

Currently the "favourite" button is only available in the selected abstract mode of the abstract-list view.