### PR TITLE
[docker] Enable restart

### DIFF
--- a/docker_startup.sh
+++ b/docker_startup.sh
@@ -1,7 +1,14 @@
 #!/usr/bin/env bash
 
-# copy any external config files to the frameworks config folder
+# Copy any external config files to the frameworks config folder
 cp /srv/ext_conf/* /srv/gca/conf/
+
+# Cleanup leftover pid file if a server crash has happened,
+# otherwise the service cannot be restarted.
+PLAY_RUNNING="$(pgrep -F /srv/gca/target/universal/stage/RUNNING_PID)"
+if [ -z $PLAY_RUNNING ]; then
+   rm /srv/gca/target/universal/stage/RUNNING_PID
+fi
 
 activator start
 


### PR DESCRIPTION
When the play framework is not properly shut down, a PID file remains that needs to be cleaned up before restarting the service. This PR adds the required lines to the docker startup script to ensure a docker restart will succeed.