### PR TITLE
Issue fixes A for release 2019

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,53 @@
+# Changelog
+
+Used to document all changes from previous releases and collect changes 
+until the next release.
+
+# Latest changes in master
+
+## Features
+- Added docker support to the project. GCA-Web can now also be run using docker containers.
+  The latest buids can be found at [dockerhub](https://hub.docker.com/r/gnode/gca/builds).
+- Added a "Favourite Abstracts" feature to the page. Viewed abstracts can now be
+  marked and a list of favoured abstracts can be separately accessed.
+- Login behavior has been changed to support page redirecting to the original page after 
+  a login has occurred. See issue #361 for details.
+- Due to previously added features like "Schedule" or "Location" the navigation bar
+  has been restructured to a two row display to accommodate all new features.
+- Various smaller changes in behavior have been made to the conference administration page.
+  See issues #341 and #437 for details.
+- Various smaller changes in behavior have been made to the abstract submission page.
+  See issues #201, #338, #339, #397 and #437 for details.
+
+## Fixes
+- JavaScript code files have been sanitized. Unsanitized code lead to premature stop of 
+  JavaScript execution in more strict browsers like IE and Edge. See #445 for details.
+- Various fixes have been applied to the abstract submission. See #444 and #439 for details.
+- Various fixes have been applied to the conference administration. See #317, #425, #439 and #444 for details 
+- The site now displays pages within the GCA-Web scope on notAuthenticated and notAuthorized 
+  access. See #444 for details.
+- The password reset page now properly resolves error template messages. See #434 for details.
+
+
+# Release 1.1
+Major changes since the last release:
+
+- Support for conference description
+- Support for conference schedule
+- Support for conference locations and floorplans
+- Support for multiple abstract figures
+- Support for offline viewing on mobile devices
+- Support for Docker deployment
+- iOS and Android support
+- Changes to the database schema of the project have been introduced. See #309 and #319 for details.
+
+
+# Release 1.0
+Major changes from the previous version of the GCA-Web include:
+
+- migration to play framework 2.3
+- migration from securesocial to silhouette authentication frame work
+
+
+# Release 0.1
+First stable release for the BCCN 2014

--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.org/G-Node/GCA-Web.png?branch=master)](https://travis-ci.org/G-Node/GCA-Web)
+[![Docker Automated build](https://img.shields.io/docker/automated/gnode/gca.svg)](https://hub.docker.com/r/gnode/gca/builds)
 [![StackShare](https://img.shields.io/badge/tech-stack-0690fa.svg?style=flat)](https://stackshare.io/cgars/gca-web)
 
 G-Node Conference Application Suite - Web Application

--- a/Readme.md
+++ b/Readme.md
@@ -1,22 +1,25 @@
+[![Build Status](https://travis-ci.org/G-Node/GCA-Web.png?branch=master)](https://travis-ci.org/G-Node/GCA-Web)
+[![StackShare](https://img.shields.io/badge/tech-stack-0690fa.svg?style=flat)](https://stackshare.io/cgars/gca-web)
+
 G-Node Conference Application Suite - Web Application
 =====================================================
 
-This project provides an online application for the submission and management of abstracts to conferences in the scientific community (focus life sciences).
+This project provides an online application for the submission and management of abstracts to conferences 
+in the scientific community (focus life sciences).
 
 Features include:
-- management of multiple individual conferences
-- admin based conference workflow from open, active to closed
-- submission and editing of abstracts for open conferences
-- abstract workflow on a user/admin based system from submitted to accepted/rejected
-- abstract viewer for open and closed conferences
+- Management of multiple individual conferences
+- Admin based conference workflow from open, active to closed
+- Submission and editing of abstracts for open conferences
+- Abstract workflow on a user/admin based system from submitted to accepted/rejected
+- Abstract viewer for open and closed conferences
+- Conference locations and floorplans
+- Conference schedule
+- Favourite abstracts
+- Supports offline viewing of individual conferences
 
 The current version is stable.
 
 A previous version of the application can be found in the "oldstable" branch.
 
-Please find the latest release notes in our [wiki release notes](https://github.com/G-Node/GCA-Web/wiki) section.
-
---
-
-[![Build Status](https://travis-ci.org/G-Node/GCA-Web.png?branch=master)](https://travis-ci.org/G-Node/GCA-Web)
-[![StackShare](https://img.shields.io/badge/tech-stack-0690fa.svg?style=flat)](https://stackshare.io/cgars/gca-web)
+Please find the latest release notes in the [release section](https://github.com/G-Node/GCA-Web/releases).

--- a/app/assets/javascripts/abstract-list.js
+++ b/app/assets/javascripts/abstract-list.js
@@ -133,9 +133,30 @@ require(["lib/models", "lib/tools", "knockout", "sammy", "lib/offline"], functio
             }
         };
 
-        self.disfavourAbstract = function(abstract) {
-            var absUrl = "/api/abstracts/" + abstract.uuid + "/removefavuser";
-            return absUrl;
+        self.disfavourAbstract = function () {
+            var selectedAbstract = self.selectedAbstract();
+            if (selectedAbstract !== null && selectedAbstract !== undefined) {
+                $.ajax({
+                    data: JSON.stringify(selectedAbstract.uuid),
+                    async: false,
+                    url: "/api/abstracts/" + selectedAbstract.uuid + "/removefavuser",
+                    type: "DELETE",
+                    success: success,
+                    error: fail,
+                    contentType: "application/json",
+                    cache: false
+                });
+
+                function success(obj) {
+                    // Reload the abstract view to refresh the favourite status
+                    self.showAbstractByUUID(obj);
+                    self.setInfo("Abstract has been removed from the favourite abstracts list");
+                }
+
+                function fail() {
+                    self.setError("Error", "Unable to remove abstract from the favourite abstracts list");
+                }
+            }
         };
 
         self.showAbstractByUUID = function(uuid) {

--- a/app/assets/javascripts/abstract-list.js
+++ b/app/assets/javascripts/abstract-list.js
@@ -107,9 +107,30 @@ require(["lib/models", "lib/tools", "knockout", "sammy", "lib/offline"], functio
             MathJax.Hub.Queue(["Typeset", MathJax.Hub]);
         };
 
-        self.favourAbstract = function(abstract) {
-            var absUrl = "/api/abstracts/" + abstract.uuid + "/addfavuser";
-            return absUrl;
+        self.favourAbstract = function () {
+            var selectedAbstract = self.selectedAbstract();
+            if (selectedAbstract !== null && selectedAbstract !== undefined) {
+                $.ajax({
+                    data: JSON.stringify(selectedAbstract.uuid),
+                    async: false,
+                    url: "/api/abstracts/" + selectedAbstract.uuid + "/addfavuser",
+                    type: "PUT",
+                    success: success,
+                    error: fail,
+                    contentType: "application/json",
+                    cache: false
+                });
+
+                function success(obj) {
+                    // Reload the abstract view to refresh the favourite status
+                    self.showAbstractByUUID(obj);
+                    self.setInfo("Abstract has been added to the favourite abstracts list");
+                }
+
+                function fail() {
+                    self.setError("Error", "Unable to add abstract to the favourite abstracts list");
+                }
+            }
         };
 
         self.disfavourAbstract = function(abstract) {

--- a/app/assets/javascripts/abstract-list.js
+++ b/app/assets/javascripts/abstract-list.js
@@ -37,6 +37,13 @@ require(["lib/models", "lib/tools", "knockout", "sammy", "lib/offline"], functio
             MathJax.Hub.Configured();
         };
 
+        self.localConferenceLink = ko.computed(function() {
+            if (self.conference() === null || self.conference() === undefined) {
+                return "";
+            }
+            return "/conference/" + self.conference().short + "/abstracts";
+        });
+
         // Duplicate code with setError. Implement MessageBox instead and remove code from here
         self.setInfo = function(text) {
             self.messageSuccess({message: text});

--- a/app/assets/javascripts/abstract-list.js
+++ b/app/assets/javascripts/abstract-list.js
@@ -24,6 +24,7 @@ require(["lib/models", "lib/tools", "knockout", "sammy", "lib/offline"], functio
         self.isFavouriteAbstract = ko.observable(false);
         self.groups = ko.observableArray(null);
         self.error = ko.observable(false);
+        self.messageSuccess = ko.observable(false);
 
         // maps for uuid -> abstract, doi -> abstract,
         //          neighbours -> prev & next of current list
@@ -34,6 +35,12 @@ require(["lib/models", "lib/tools", "knockout", "sammy", "lib/offline"], functio
             ko.applyBindings(window.abstractList);
             // start MathJax
             MathJax.Hub.Configured();
+        };
+
+        // Duplicate code with setError. Implement MessageBox instead and remove code from here
+        self.setInfo = function(text) {
+            self.messageSuccess({message: text});
+            self.isLoading(false);
         };
 
         self.setError = function(level, text) {

--- a/app/assets/javascripts/abstract-list.js
+++ b/app/assets/javascripts/abstract-list.js
@@ -2,7 +2,6 @@ require(["main"], function () {
 require(["lib/models", "lib/tools", "knockout", "sammy", "lib/offline"], function(models, tools, ko, Sammy, offline) {
     "use strict";
 
-
     /**
      * AbstractList view model.
      *
@@ -12,8 +11,7 @@ require(["lib/models", "lib/tools", "knockout", "sammy", "lib/offline"], functio
      * @constructor
      */
     function AbstractListViewModel(confId, loggedIn) {
-
-        if (! (this instanceof AbstractListViewModel)) {
+        if (!(this instanceof AbstractListViewModel)) {
             return new AbstractListViewModel(confId, loggedIn);
         }
 
@@ -27,24 +25,24 @@ require(["lib/models", "lib/tools", "knockout", "sammy", "lib/offline"], functio
         self.groups = ko.observableArray(null);
         self.error = ko.observable(false);
 
-        //maps for uuid -> abstract, doi -> abstract,
-        //         neighbours -> prev & next of current list
+        // maps for uuid -> abstract, doi -> abstract,
+        //          neighbours -> prev & next of current list
         self.uuidMap = {};
         self.neighbours = {};
 
-
         self.init = function() {
             ko.applyBindings(window.abstractList);
-            MathJax.Hub.Configured(); //start MathJax
+            // start MathJax
+            MathJax.Hub.Configured();
         };
 
         self.setError = function(level, text) {
-            self.error({message: text, level: 'alert-' + level});
+            self.error({message: text, level: "alert-" + level});
             self.isLoading(false);
         };
 
         self.makeLink = function(abstract) {
-            return '#' + '/uuid/' + abstract.uuid;
+            return "#/uuid/" + abstract.uuid;
         };
 
         self.getGroupById = function(groupid) {
@@ -79,29 +77,27 @@ require(["lib/models", "lib/tools", "knockout", "sammy", "lib/offline"], functio
             return prefix + "&nbsp;" + aid;
         };
 
-
         self.selectAbstract = function(abstract) {
-            console.log("Selecting abstract " + abstract.uuid + " " + abstract.toString());
             window.location = self.makeLink(abstract);
         };
 
         self.showAbstract = function(abstract) {
-
             self.abstracts(null);
             var isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
             if (isMobile) {
-                console.log("Mobile figure hotfix in progress, adjusting URL")
+                // Mobile figure hotfix, adjusting URL
                 for (let fig of abstract.figures) {
-                    fig.URL = fig.URL + "mobile"
+                    fig.URL = fig.URL + "mobile";
                 }
             }
             self.selectedAbstract(abstract);
-            document.title = abstract.title; //FIXME add conference
-            //if user is not logged in
-            if(loggedIn.indexOf('true')>=0){
+            document.title = abstract.title;
+            // if user is not logged in
+            if (loggedIn.indexOf("true") >= 0) {
                 self.isFavourite(abstract);
             }
-            MathJax.Hub.Queue(["Typeset",MathJax.Hub]); //re-render equations
+            // re-render equations
+            MathJax.Hub.Queue(["Typeset", MathJax.Hub]);
         };
 
         self.favourAbstract = function(abstract) {
@@ -115,9 +111,7 @@ require(["lib/models", "lib/tools", "knockout", "sammy", "lib/offline"], functio
         };
 
         self.showAbstractByUUID = function(uuid) {
-
-            if(!uuid in self.uuidMap) {
-                console.log("Warning uuid to show not in map");
+            if (!uuid in self.uuidMap) {
                 return;
             }
 
@@ -125,33 +119,23 @@ require(["lib/models", "lib/tools", "knockout", "sammy", "lib/offline"], functio
         };
 
         self.activateGroup = function(groupId) {
-
         };
 
-
         self.showAbstractsByGroup = function(groupId) {
-
-            console.log("groupid" + groupId);
-
             var selGroup = null;
             for (var i = 0; i < self.groups().length; i++) {
                 var curGroup = self.groups()[i];
                 if (curGroup.short === groupId) {
                     selGroup = curGroup;
-                    //we don't break here because we want to set
-                    //all the groups 'state' member
-
+                    // We don't break here because we want to set all the groups 'state' member
                     curGroup.state("active");
                 } else {
                     curGroup.state("");
                 }
             }
 
-
-
             if (selGroup === null) {
-                self.setError("danger", "Internal error [group selection]!")
-                console.log("Error invalid group selected");
+                self.setError("danger", "Internal error [group selection]!");
                 self.showAbstractList([]);
                 return;
             }
@@ -177,9 +161,7 @@ require(["lib/models", "lib/tools", "knockout", "sammy", "lib/offline"], functio
             self.neighbours = self.makeNeighboursMap(theList);
         };
 
-
         self.buildGroups = function() {
-
             function mkGroup(_prefix, _name, _short) {
                 return {
                     prefix: _prefix,
@@ -201,9 +183,10 @@ require(["lib/models", "lib/tools", "knockout", "sammy", "lib/offline"], functio
           self.groups(theGroups);
         };
 
-        //map related stuff
+        // Map related stuff
         self.buildMaps = function() {
-            self.uuidMap = {}; //empty the map
+            // Empty the map
+            self.uuidMap = {};
             for (var i = 0; i < self.abstractsData.length; i++) {
                 var currentAbstract = self.abstractsData[i];
                 self.uuidMap[currentAbstract.uuid] = currentAbstract;
@@ -217,20 +200,20 @@ require(["lib/models", "lib/tools", "knockout", "sammy", "lib/offline"], functio
                 return theMap;
             }
 
-            for(var i = 0; i < objs.length; i++) {
+            for (var i = 0; i < objs.length; i++) {
                 theMap[objs[i].uuid] = {
-                    prev: i > 0 ? self.makeLink(objs[i-1]): null,
-                    next: i + 1 != objs.length ? self.makeLink(objs[i+1]) : null
-                }
+                    prev: i > 0 ? self.makeLink(objs[i - 1]) : null,
+                    next: i + 1 != objs.length ? self.makeLink(objs[i + 1]) : null
+                };
             }
 
             return theMap;
         };
 
         self.nextAbstract = function(abstract) {
-          var uuid = abstract.uuid;
+            var uuid = abstract.uuid;
 
-            if(!uuid in self.neighbours) {
+            if (!uuid in self.neighbours) {
                 return null;
             }
 
@@ -240,7 +223,7 @@ require(["lib/models", "lib/tools", "knockout", "sammy", "lib/offline"], functio
         self.prevAbstract = function(abstract) {
             var uuid = abstract.uuid;
 
-            if(!uuid in self.neighbours) {
+            if (!uuid in self.neighbours) {
                 return null;
             }
 
@@ -250,24 +233,20 @@ require(["lib/models", "lib/tools", "knockout", "sammy", "lib/offline"], functio
         self.isFavourite = function(abstract) {
             var uuid = abstract.uuid;
             var favUsersUrl = "/api/user/self/abstract/" + uuid + "/isfavuser";
-            $.get(favUsersUrl,onFavUserData).fail(self.ioFailHandler);
+            $.get(favUsersUrl, onFavUserData).fail(self.ioFailHandler);
             function onFavUserData(isFavUser) {
-                console.log('IsFavUser '+ isFavUser);
-                var IFUBool = (isFavUser == 'true');
-                console.log('IsFavUser IFUBool '+ IFUBool);
+                var IFUBool = isFavUser === "true";
                 self.isFavouriteAbstract(IFUBool);
             }
         };
 
-        //Data IO
+        // Data IO
         self.ioFailHandler = function(jqxhr, textStatus, error) {
             var err = textStatus + ", " + error;
-            console.log( "Request Failed: " + err );
-            self.setError("danger", "Error while fetching data from server: <br\\>" + error);
+            self.setError("danger", "Error while fetching data from server: <br\\>" + err);
         };
 
         self.ensureDataAndThen = function(doAfter) {
-            console.log("ensureDataAndThen::");
             self.isLoading(true);
             if (self.abstractsData !== null) {
                 doAfter();
@@ -275,20 +254,20 @@ require(["lib/models", "lib/tools", "knockout", "sammy", "lib/offline"], functio
                 return;
             }
 
-            //now load the data from the server
-            var confURL ="/api/conferences/" + confId;
+            // Now load the data from the server
+            var confURL = "/api/conferences/" + confId;
             offline.requestJSON(confId, confURL, onConferenceData, self.ioFailHandler);
 
-            //conference data
+            // Conference data
             function onConferenceData(confObj) {
                 var conf = models.Conference.fromObject(confObj);
                 self.conference(conf);
                 self.buildGroups();
-                //now load the abstract data
+                // Now load the abstract data
                 offline.requestJSON(conf.uuid + "abstracts", conf.abstracts, onAbstractData, self.ioFailHandler);
             }
 
-            //abstract data
+            // Abstract data
             function onAbstractData(absArray) {
                 var absList = models.Abstract.fromArray(absArray);
                 self.abstractsData = absList;
@@ -301,47 +280,35 @@ require(["lib/models", "lib/tools", "knockout", "sammy", "lib/offline"], functio
             }
         };
 
-        // client-side routes
+        // Client-side routes
         Sammy(function() {
-
-            this.get('#/uuid/:uuid', function() {
-                var uuid = this.params['uuid'];
-                console.log("Sammy::get::uuid [" + uuid + "]");
+            this.get("#/uuid/:uuid", function() {
+                var uuid = this.params["uuid"];
                 self.ensureDataAndThen(function () {
                     self.showAbstractByUUID(uuid);
                 });
             });
 
-            this.get('#/groups/:group', function() {
-                var group = this.params['group'];
-                console.log("Sammy::get::group [" + group + "]");
+            this.get("#/groups/:group", function() {
+                var group = this.params["group"];
                 self.ensureDataAndThen(function () {
                     self.showAbstractsByGroup(group);
                 });
             });
 
-
-            this.get('#/', function() {
-                console.log('Sammy::get::');
+            this.get("#/", function() {
                 self.ensureDataAndThen(function () {
                     self.showAbstractList(self.abstractsData);
                 });
             });
-
-        }).run('#/');
-
+        }).run("#/");
     }
 
-
     $(document).ready(function() {
-
         var data = tools.hiddenData();
 
-        console.log(data.conferenceUuid,data.loggedIn);
-
-        window.abstractList = AbstractListViewModel(data.conferenceUuid,data.loggedIn);
+        window.abstractList = AbstractListViewModel(data.conferenceUuid, data.loggedIn);
         window.abstractList.init();
     });
-
 });
 });

--- a/app/assets/javascripts/abstract-viewer.js
+++ b/app/assets/javascripts/abstract-viewer.js
@@ -3,7 +3,6 @@ require(["lib/models", "lib/tools", "lib/msg", "lib/astate", "knockout", "lib/of
     "use strict";
 
     function AbstractViewerViewModel(confId, abstrId, isAdmin, isOwner) {
-
         if (!(this instanceof AbstractViewerViewModel)) {
             return new AbstractViewerViewModel(confId, abstrId, isAdmin, isOwner);
         }
@@ -17,7 +16,8 @@ require(["lib/models", "lib/tools", "lib/msg", "lib/astate", "knockout", "lib/of
         self.init = function() {
             self.loadAbstract();
             ko.applyBindings(window.viewer);
-            MathJax.Hub.Configured(); //start MathJax
+            // start MathJax
+            MathJax.Hub.Configured();
         };
 
         self.ioFailHandler = function(jqxhr, textStatus, error) {
@@ -25,23 +25,22 @@ require(["lib/models", "lib/tools", "lib/msg", "lib/astate", "knockout", "lib/of
         };
 
         self.loadAbstract = function() {
-
             self.isLoading(true);
-            var absURL ="/api/abstracts/" + abstrId;
+            var absURL = "/api/abstracts/" + abstrId;
             offline.requestJSON(abstrId, absURL, onAbstractData, self.ioFailHandler);
 
-            //conference data
+            // Conference data
             function onAbstractData(abstrObj) {
                 var abstr = models.Abstract.fromObject(abstrObj);
                 self.selectedAbstract(abstr);
-                MathJax.Hub.Queue(["Typeset",MathJax.Hub]); //re-render equations
+                // Re-render equations
+                MathJax.Hub.Queue(["Typeset", MathJax.Hub]);
 
                 self.loadConference();
 
-                if(isAdmin === "true" || isOwner === "true") {
+                if (isAdmin === "true" || isOwner === "true") {
                     var logUrl = "/api/abstracts/" + abstrId + "/stateLog";
                     $.getJSON(logUrl, onLogData).fail(self.ioFailHandler);
-
                 } else {
                     self.isLoading(false);
                 }
@@ -55,31 +54,23 @@ require(["lib/models", "lib/tools", "lib/msg", "lib/astate", "knockout", "lib/of
         };
 
         self.loadConference = function() {
-            var confUrl = "/api/conferences/" + confId; // we should be reading this from the abstract
+            // We should be reading this from the abstract
+            var confUrl = "/api/conferences/" + confId;
             offline.requestJSON(confId, confUrl, onConferenceData, self.ioFailHandler);
 
             function onConferenceData(confObj) {
                 var conf = models.Conference.fromObject(confObj);
                 self.conference(conf);
             }
-
         };
     }
 
-    // start the editor
+    // Start the editor
     $(document).ready(function() {
-
         var data = tools.hiddenData();
-
-        console.log(data["conferenceUuid"]);
-        console.log(data["abstractUuid"]);
-        console.log(data["isAdmin"]);
-        console.log(data["isOwner"]);
-
         window.viewer = AbstractViewerViewModel(data["conferenceUuid"], data["abstractUuid"],
                                                 data["isAdmin"], data["isOwner"]);
         window.viewer.init();
     });
-
 });
 });

--- a/app/assets/javascripts/abstracts-favourite.js
+++ b/app/assets/javascripts/abstracts-favourite.js
@@ -2,17 +2,14 @@ require(["main"], function () {
     require(["lib/models", "lib/tools", "knockout", "sammy", "lib/offline"], function (models, tools, ko, Sammy, offline) {
         "use strict";
 
-
         /**
-         * AbstractList view model.
+         * Favourite Abstracts view model.
          *
          *
-         * @param confId
-         * @returns {AbstractListViewModel}
+         * @returns {FavouriteAbstractsViewModel}
          * @constructor
          */
         function FavouriteAbstractsViewModel() {
-
             if (!(this instanceof FavouriteAbstractsViewModel)) {
                 return new FavouriteAbstractsViewModel();
             }
@@ -24,12 +21,10 @@ require(["main"], function () {
             self.noFavouriteAbstracts = ko.observable(false);
             self.error = ko.observable(false);
 
-
             self.setError = function (level, text) {
-                self.error({message: text, level: 'alert-' + level});
+                self.error({message: text, level: "alert-" + level});
                 self.isLoading(false);
             };
-
 
             self.init = function () {
                 ko.applyBindings(window.dashboard);
@@ -39,29 +34,24 @@ require(["main"], function () {
                 return "/myabstracts/" + abstract.uuid + "/edit";
             };
 
-
-            //Data IO
+            // Data IO
             self.ioFailHandler = function (jqxhr, textStatus, error) {
-                if(find(jqxhr.responseText,"No favourite abstracts") != -1){
+                if (find(jqxhr.responseText, "No favourite abstracts") != -1) {
                     self.noFavouriteAbstracts(true);
                     self.isLoading(false);
-                }else {
+                } else {
                     var err = textStatus + ", " + error + ", " + jqxhr.responseText;
-                    console.log("Request Failed: " + err);
                     self.setError("danger", "Error while loading data [" + err + "]!");
                 }
             };
 
             self.ensureDataAndThen = function (doAfter) {
-                console.log("ensureDataAndThen::");
-
-                //now load the data from the server
+                // Load the data from the server
                 var confURL = "/api/user/self/conffavouriteabstracts";
                 $.getJSON(confURL, onConferenceData).fail(self.ioFailHandler);
 
-                //conference data
+                // Conference data
                 function onConferenceData(confObj) {
-                    console.log("+ onConferenceData")
                     var confs = models.Conference.fromArray(confObj);
                     if (confs !== null) {
                         confs.forEach(function (current) {
@@ -69,9 +59,7 @@ require(["main"], function () {
                             current.localConferenceLink = ko.computed(function() {
                                 return "/conference/" + current.short + "/abstracts";
                             });
-                            console.log(current.short);
                         });
-
                     }
 
                     self.conferences(confs);
@@ -79,9 +67,8 @@ require(["main"], function () {
                     if (confs !== null) {
                         confs.forEach(function (current) {
                             var absUrl = "/api/user/self/conferences/" + current.uuid + "/favouriteabstracts";
-                            //$.getJSON(absUrl, onAbstractData(current)).fail(self.ioFailHandler);
+                            // $.getJSON(absUrl, onAbstractData(current)).fail(self.ioFailHandler);
                             offline.requestJSON(current.uuid, absUrl, onAbstractData(current), self.ioFailHandler);
-
                         });
                     }
 
@@ -93,7 +80,6 @@ require(["main"], function () {
                         var absList = models.Abstract.fromArray(abstractList);
                         absList.forEach(function (abstr) {
                             abstr.createLink = ko.computed(function () {
-                                console.log("Creating link: "+ abstr.title)
                                 return {
                                     absLink: "/conference/" + currentConf.short + "/abstracts#/uuid/" + abstr.uuid
                                 };
@@ -101,33 +87,25 @@ require(["main"], function () {
                         });
 
                         currentConf.abstracts(absList);
-                    }
+                    };
                 }
             };
 
-
             // client-side routes
             Sammy(function () {
-
-                this.get('#/', function () {
-                    console.log('Sammy::get::');
+                this.get("#/", function () {
                     self.ensureDataAndThen(function () {
                         self.isLoading(false);
                     });
                 });
-
-            }).run('#/');
-
+            }).run("#/");
         }
 
         $(document).ready(function () {
-
             var data = tools.hiddenData();
-
 
             window.dashboard = FavouriteAbstractsViewModel();
             window.dashboard.init();
         });
-
     });
 });

--- a/app/assets/javascripts/abstracts-favourite.js
+++ b/app/assets/javascripts/abstracts-favourite.js
@@ -66,6 +66,9 @@ require(["main"], function () {
                     if (confs !== null) {
                         confs.forEach(function (current) {
                             current.abstracts = ko.observableArray(null);
+                            current.localConferenceLink = ko.computed(function() {
+                                return "/conference/" + current.short + "/abstracts";
+                            });
                             console.log(current.short);
                         });
 
@@ -90,6 +93,7 @@ require(["main"], function () {
                         var absList = models.Abstract.fromArray(abstractList);
                         absList.forEach(function (abstr) {
                             abstr.createLink = ko.computed(function () {
+                                console.log("Creating link: "+ abstr.title)
                                 return {
                                     absLink: "/conference/" + currentConf.short + "/abstracts#/uuid/" + abstr.uuid
                                 };

--- a/app/assets/javascripts/admin-abstracts.js
+++ b/app/assets/javascripts/admin-abstracts.js
@@ -93,11 +93,6 @@ require(["lib/models", "lib/tools", "lib/astate", "knockout"], function(models, 
             }
         };
 
-        self.onSelStateClick = function() {
-            console.log("clicked");
-            console.log($(this));
-        };
-
         self.setError = function(level, text, description) {
             if (text === null) {
                 self.message(null);

--- a/app/assets/javascripts/admin-abstracts.js
+++ b/app/assets/javascripts/admin-abstracts.js
@@ -2,18 +2,16 @@ require(["main"], function () {
 require(["lib/models", "lib/tools", "lib/astate", "knockout"], function(models, tools, astate, ko) {
     "use strict";
 
-
     /**
      * admin/abstracts view model.
      *
      *
      * @param confId
-     * @returns {OwnersListViewModel}
+     * @returns {adminAbstractsViewModel}
      * @constructor
      */
     function adminAbstractsViewModel(confId) {
-
-        if (! (this instanceof adminAbstractsViewModel)) {
+        if (!(this instanceof adminAbstractsViewModel)) {
             return new adminAbstractsViewModel(confId);
         }
 
@@ -25,20 +23,20 @@ require(["lib/models", "lib/tools", "lib/astate", "knockout"], function(models, 
         self.abstracts = ko.observableArray(null);
         self.abstractNumbers = ko.observable({ total: 0, active: 0 });
 
-        //state related things
+        // State related things
         self.stateHelper = astate.changeHelper;
         self.selectedAbstract = ko.observable(null);
-        self.selectableStates = ko.observableArray(['InPreparation', 'Submitted', 'InReview', 'Accepted', 'Rejected', 'InRevision', 'Withdrawn']);
+        self.selectableStates = ko.observableArray(["InPreparation", "Submitted", "InReview", "Accepted", "Rejected", "InRevision", "Withdrawn"]);
 
-        self.selectedStates = ko.observableArray(['Submitted', 'InReview', 'Accepted', 'Rejected', 'InRevision']);
+        self.selectedStates = ko.observableArray(["Submitted", "InReview", "Accepted", "Rejected", "InRevision"]);
 
         ko.bindingHandlers.bsChecked = {
             init: function(element, valueAccessor) {
                 $(element).change(function() {
-
                     var value = ko.unwrap(valueAccessor());
                     var this_val = $(this).val();
-                    var is_active = ! $(this.parentElement).hasClass('active'); //we are doing this before the change
+                    // We are doing this before the change
+                    var is_active = !$(this.parentElement).hasClass("active");
                     var idx = value.indexOf(this_val);
 
                     var change = true;
@@ -51,10 +49,9 @@ require(["lib/models", "lib/tools", "lib/astate", "knockout"], function(models, 
                     }
 
                     if (change) {
-                        //we don't seem to trigger notifications automatically
-                        valueAccessor().notifySubscribers(value, 'arrayChange');
+                        // We don't seem to trigger notifications automatically
+                        valueAccessor().notifySubscribers(value, "arrayChange");
                     }
-
                 });
             },
             update: function(element, valueAccessor, allBindings) {
@@ -64,10 +61,10 @@ require(["lib/models", "lib/tools", "lib/astate", "knockout"], function(models, 
                 var idx = value.indexOf(myval);
 
                 var should_be_active = idx > -1;
-                var is_active = $(element.parentElement).hasClass('active');
+                var is_active = $(element.parentElement).hasClass("active");
 
                 if (should_be_active != is_active) {
-                    $(element.parentElement).toggleClass('active');
+                    $(element.parentElement).toggleClass("active");
                 }
             }
         };
@@ -81,7 +78,7 @@ require(["lib/models", "lib/tools", "lib/astate", "knockout"], function(models, 
             self.abstractNumbers({ total: self.abstractsData.length, active: new_list.length });
         };
 
-        self.selectedStates.subscribe(self.showAbstractsWithState, 'null', 'arrayChange');
+        self.selectedStates.subscribe(self.showAbstractsWithState, "null", "arrayChange");
 
         self.init = function() {
             self.ensureData();
@@ -97,7 +94,7 @@ require(["lib/models", "lib/tools", "lib/astate", "knockout"], function(models, 
         };
 
         self.onSelStateClick = function() {
-            console.log('clicked');
+            console.log("clicked");
             console.log($(this));
         };
 
@@ -105,11 +102,11 @@ require(["lib/models", "lib/tools", "lib/astate", "knockout"], function(models, 
             if (text === null) {
                 self.message(null);
             } else {
-                self.message({message: text, level: 'alert-' + level, desc: description});
+                self.message({message: text, level: "alert-" + level, desc: description});
             }
         };
 
-        //helper functions
+        // Helper functions
         self.makeAbstractLink = function(abstract) {
             return "/myabstracts/" + abstract.uuid + "/edit";
         };
@@ -123,7 +120,7 @@ require(["lib/models", "lib/tools", "lib/astate", "knockout"], function(models, 
             }
 
             abstract.state("Saving...");
-            $.ajax("/api/abstracts/" + abstract.uuid + '/state', {
+            $.ajax("/api/abstracts/" + abstract.uuid + "/state", {
                 data: JSON.stringify(data),
                 type: "PUT",
                 contentType: "application/json",
@@ -138,22 +135,22 @@ require(["lib/models", "lib/tools", "lib/astate", "knockout"], function(models, 
         };
 
         self.beginStateChange = function(abstract) {
-            $('#note').val(""); //reset the message box
-            $('#state-dialog').modal('show');
+            // Reset the message box
+            $("#note").val("");
+            $("#state-dialog").modal("show");
             self.selectedAbstract(abstract);
         };
 
         self.finishStateChange = function() {
-            var note = $('#note').val();
-            var state = $('#state-dialog').find('select').val();
+            var note = $("#note").val();
+            var state = $("#state-dialog").find("select").val();
 
             self.setState(self.selectedAbstract(), state, note);
             self.selectedAbstract();
         };
 
         self.mkAuthorList = function(abstract) {
-
-            if(abstract.authors.length < 1) {
+            if (abstract.authors.length < 1) {
                 return "";
             }
 
@@ -166,44 +163,39 @@ require(["lib/models", "lib/tools", "lib/astate", "knockout"], function(models, 
             return text;
         };
 
-        //Data IO
+        // Data IO
         self.ioFailHandler = function(jqxhr, textStatus, error) {
             var err = textStatus + ", " + error;
-            console.log( "Request Failed: " + err );
-            self.setError("danger", "Error while fetching data from server", error);
+            self.setError("danger", "Error while fetching data from server: ", err);
         };
 
         self.ensureData = function() {
-            console.log("ensureDataAndThen::");
             self.isLoading(true);
             if (self.abstractsData !== null) {
                 self.isLoading(false);
                 return;
             }
 
-            //now load the data from the server
-            var confURL ="/api/conferences/" + confId;
+            var confURL = "/api/conferences/" + confId;
             $.getJSON(confURL, onConferenceData).fail(self.ioFailHandler);
 
-            //conference data
+            // Conference data
             function onConferenceData(confObj) {
                 var conf = models.Conference.fromObject(confObj);
                 self.conference(conf);
-                //now load the abstract data
                 $.getJSON(confURL + "/allAbstracts", onAbstractData).fail(self.ioFailHandler);
             }
 
-            //abstract data
+            // Abstract data
             function onAbstractData(absArray) {
                 var absList = models.Abstract.fromArray(absArray);
 
                 absList.forEach(function (abstr) {
-
-                    abstr.makeObservable(['state']);
+                    abstr.makeObservable(["state"]);
                     abstr.possibleStates = ko.computed(function () {
                         var fromState = abstr.state();
 
-                        if (fromState === 'Saving...') {
+                        if (fromState === "Saving...") {
                             return [];
                         }
 
@@ -211,15 +203,14 @@ require(["lib/models", "lib/tools", "lib/astate", "knockout"], function(models, 
                     });
 
                     abstr.viewEditCtx = ko.computed(function () {
-                        //only time that admins can make changes is in the InRevision state
-                        var canEdit = abstr.state() == "InRevision";
+                        // Only time that admins can make changes is in the InRevision state
+                        var canEdit = abstr.state() === "InRevision";
 
                         return {
                             link: canEdit ? "/myabstracts/" + abstr.uuid + "/edit" : "/abstracts/" + abstr.uuid,
                             label: canEdit ? "Edit" : "View",
                             btn: canEdit ? "btn-danger" : "btn-primary"
                         };
-
                     });
                 });
 
@@ -228,19 +219,13 @@ require(["lib/models", "lib/tools", "lib/astate", "knockout"], function(models, 
                 self.isLoading(false);
             }
         };
-
     }
 
     $(document).ready(function() {
-
         var data = tools.hiddenData();
-
-        console.log(data.conferenceUuid);
 
         window.dashboard = adminAbstractsViewModel(data.conferenceUuid);
         window.dashboard.init();
     });
-
-
 });
 });

--- a/app/assets/javascripts/admin-accounts.js
+++ b/app/assets/javascripts/admin-accounts.js
@@ -3,8 +3,6 @@ require(["lib/models", "lib/tools", "lib/msg", "knockout"], function(models, too
     "use strict";
 
     function AdminAccountsViewModel() {
-
-
         if (!(this instanceof AdminAccountsViewModel)) {
             return new AdminAccountsViewModel();
         }
@@ -22,8 +20,7 @@ require(["lib/models", "lib/tools", "lib/msg", "knockout"], function(models, too
         };
 
         self.loadAccounts = function() {
-
-            var confURL ="/api/user/list";
+            var confURL = "/api/user/list";
             $.getJSON(confURL, onAccountData).fail(function() {
                 self.setError("Error", "Could not load accounts from server!");
             });
@@ -32,15 +29,13 @@ require(["lib/models", "lib/tools", "lib/msg", "knockout"], function(models, too
                 var acc = models.ObservableAccount.fromArray(accountData);
                 self.accounts(acc);
             }
-        }
+        };
     }
 
     // the show begins
     $(document).ready(function() {
-
         window.dashboard = AdminAccountsViewModel();
         window.dashboard.init();
     });
-
 });
 });

--- a/app/assets/javascripts/admin-conference.js
+++ b/app/assets/javascripts/admin-conference.js
@@ -99,7 +99,6 @@ require(["lib/models", "lib/tools", "lib/owned", "knockout", "ko.sortable", "dat
 
         self.ioFailHandler = function(jqxhr, textStatus, error) {
             var err = textStatus + ", " + error;
-            console.log("Request Failed: " + err);
             var errobj = $.parseJSON(jqxhr.responseText);
 
             var details = "";
@@ -174,7 +173,7 @@ require(["lib/models", "lib/tools", "lib/owned", "knockout", "ko.sortable", "dat
                 name.val("");
                 prefix.val("");
                 short.val("");
-                self.setError("info", 'New group added, click "Save"!');
+                self.setError("info", "New group added, click 'Save'!");
             }
         };
 
@@ -268,17 +267,18 @@ require(["lib/models", "lib/tools", "lib/owned", "knockout", "ko.sortable", "dat
             if (Array.isArray(self.conference().mFigs())) {
                 self.conference().mFigs(0);
             }
-            if (self.conference().mAbsLeng() == null) {
+            if (self.conference().mAbsLeng() === null || self.conference().mAbsLeng() === undefined) {
                 self.conference().mAbsLeng(500);
-            } else if (self.conference().mAbsLeng() == 0) {
-                self.setError("danger", "Max. Abs. Len. has to be larger than 0.");
+            }
+            if (self.conference().mAbsLeng() == 0) {
+                self.setError("danger", "Abstract length has to be larger than zero");
                 return;
             }
-            if (self.conference().short() == null) {
+            if (self.conference().short() === null || self.conference().short() === undefined) {
                 self.conference().short(self.conference().name().match(/\b(\w)/g).join("").toUpperCase());
             }
-            if (self.conference().short().replace(/\s/g,'') == '') {
-                self.setError("danger", "Conference short cannot be empty.");
+            if (self.conference().short().replace(/\s/g, "") === "") {
+                self.setError("danger", "Conference short cannot be empty");
                 return;
             }
 

--- a/app/assets/javascripts/admin-conference.js
+++ b/app/assets/javascripts/admin-conference.js
@@ -276,7 +276,7 @@ require(["lib/models", "lib/tools", "lib/owned", "knockout", "ko.sortable", "dat
             }
 
             if (self.conference().groups().length > 0) {
-                for (var i = 0; i <= self.conference().groups().length; i++) {
+                for (var i = 0; i < self.conference().groups().length; i++) {
                     var curr = self.conference().groups()[i];
                     if (!/^\d+$/.test(curr.prefix())) {
                         self.setError("danger", "Prefix can only contain numbers!");

--- a/app/assets/javascripts/admin-conference.js
+++ b/app/assets/javascripts/admin-conference.js
@@ -153,7 +153,14 @@ require(["lib/models", "lib/tools", "lib/owned", "knockout", "ko.sortable", "dat
             var name = $("#ngName");
             var prefix = $("#ngPrefix");
             var short = $("#ngShort");
-            if (!/^\d+$/.test(prefix.val())) {
+
+            var checkPref = prefix.val() !== null && prefix.val() !== undefined && prefix.val() !== "";
+            var checkShort = short.val() !== null && short.val() !== undefined && short.val() !== "";
+            var checkFull =  name.val() !== null && name.val() !== undefined && name.val() !== "";
+
+            if (!checkPref || !checkShort || !checkFull) {
+                self.setError("danger", "Prefix, short and long entries have to be provided!");
+            } else if (!/^\d+$/.test(prefix.val())) {
                 self.setError("danger", "Prefix can only contain numbers!");
             } else if (/^\d+$/.test(name.val())) {
                 self.setError("danger", "Name cannot contain only numbers!");
@@ -278,7 +285,15 @@ require(["lib/models", "lib/tools", "lib/owned", "knockout", "ko.sortable", "dat
             if (self.conference().groups().length > 0) {
                 for (var i = 0; i < self.conference().groups().length; i++) {
                     var curr = self.conference().groups()[i];
-                    if (!/^\d+$/.test(curr.prefix())) {
+
+                    var checkPref = curr.prefix() !== null && curr.prefix() !== undefined && curr.prefix() !== "";
+                    var checkShort = curr.short() !== null && curr.short() !== undefined && curr.short() !== "";
+                    var checkFull =  curr.name() !== null && curr.name() !== undefined && curr.name() !== "";
+
+                    if (!checkPref || !checkShort || !checkFull) {
+                        self.setError("danger", "Prefix, short and long entries have to be provided!");
+                        return;
+                    } else if (!/^\d+$/.test(curr.prefix())) {
                         self.setError("danger", "Prefix can only contain numbers!");
                         return;
                     } else if (/^\d+$/.test(curr.name())) {

--- a/app/assets/javascripts/browser.js
+++ b/app/assets/javascripts/browser.js
@@ -7,7 +7,7 @@ function notCompatibleBrowser() {
         var engine = ie[1].toLowerCase(),
             version = Number(ie[2]);
 
-        if (engine === 'trident') {
+        if (engine === "trident") {
             return version < 7;
         } else {
             return true;

--- a/app/assets/javascripts/editor.js
+++ b/app/assets/javascripts/editor.js
@@ -139,12 +139,12 @@ function (ko, models, tools, msg, validate, owned, astate) {
         self.checkRemovePresPref = function (warnings) {
             if (!self.conference().hasPresentationPrefs) {
                 warnings.forEach(function (currWarning) {
-                    if (currWarning.match('presentation')) {
+                    if (currWarning.match("presentation")) {
                         warnings.splice(warnings.indexOf(currWarning), 1);
                     }
                 });
             }
-        }
+        };
 
         self.validity = ko.computed(
             function() {
@@ -205,7 +205,7 @@ function (ko, models, tools, msg, validate, owned, astate) {
             if (confId) {
                 self.requestConference(confId);
             }
-            if( abstrId ) {
+            if (abstrId) {
                 self.requestAbstract(abstrId);
             } else {
                 self.abstract(models.ObservableAbstract());

--- a/app/assets/javascripts/lib/accessors.js
+++ b/app/assets/javascripts/lib/accessors.js
@@ -4,9 +4,7 @@
  * @module {lib/accessors}
  */
 define(function() {
-
     function newAcessor(initVal) {
-
         var val = initVal;
         function accessor(newVal) {
             var result = val;
@@ -23,7 +21,6 @@ define(function() {
     }
 
     function newArrayAccessor(initVal) {
-
         var val = initVal;
         function arrayAccessor(newVal) {
             var result = val;
@@ -50,5 +47,4 @@ define(function() {
         accessor: newAcessor,
         arrayAccessor: newArrayAccessor
     };
-
 });

--- a/app/assets/javascripts/lib/astate.js
+++ b/app/assets/javascripts/lib/astate.js
@@ -4,10 +4,8 @@
  */
 define(["lib/tools", "moment"], function(tools, moment) {
     "use strict";
-
     function StateChangeHelper() {
-
-        if (! (this instanceof StateChangeHelper)) {
+        if (!(this instanceof StateChangeHelper)) {
             return new StateChangeHelper();
         }
 
@@ -31,10 +29,9 @@ define(["lib/tools", "moment"], function(tools, moment) {
                 Rejected:   ["InRevision", "Withdrawn"]
             }};
 
-
         self.mkStateDisplayName = function(curState) {
-            if (curState.substr(0, 2) === 'In') {
-                return 'In ' +  curState.substr(2);
+            if (curState.substr(0, 2) === "In") {
+                return "In " +  curState.substr(2);
             }
 
             return curState;
@@ -44,7 +41,7 @@ define(["lib/tools", "moment"], function(tools, moment) {
             if (isAdmin) {
                 return self.transitionMap.admin;
             } else {
-                return self.transitionMap.owner[isClosed ? 'isClosed' : 'isOpen'];
+                return self.transitionMap.owner[isClosed ? "isClosed" : "isOpen"];
             }
         };
 
@@ -60,7 +57,6 @@ define(["lib/tools", "moment"], function(tools, moment) {
     }
 
     function StateLogHelper() {
-
         if (tools.isGlobalOrUndefined(this)) {
             return new StateLogHelper();
         }
@@ -71,15 +67,11 @@ define(["lib/tools", "moment"], function(tools, moment) {
             stateLog.forEach(function (elm) {
                 elm.formattedDate = moment(elm.timestamp).calendar();
             });
-        }
+        };
     }
-
 
     return {
         changeHelper: new StateChangeHelper(),
         logHelper: new StateLogHelper()
     };
-
 });
-
-

--- a/app/assets/javascripts/lib/models.js
+++ b/app/assets/javascripts/lib/models.js
@@ -65,15 +65,12 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
      * @constructor
      */
     function Model(uuid) {
-
         if (tools.isGlobalOrUndefined(this)) {
             return new Model(uuid);
         }
 
         var self = this;
-
         self.uuid = uuid || null;
-
 
         self.toObject = function() {
             var prop,
@@ -149,7 +146,6 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
             var obj = self.toObject();
             return JSON.stringify(obj, null, indention);
         };
-
     }
 
     /**
@@ -201,7 +197,6 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
         return created;
     };
 
-
     /**
      * Model for AbstractGroup
      *
@@ -215,8 +210,7 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
      * @public
      */
     function AbstractGroup(uuid, prefix, name, short) {
-
-        if (! (this instanceof  AbstractGroup)) {
+        if (!(this instanceof  AbstractGroup)) {
             return new AbstractGroup(uuid, prefix, name, short);
         }
 
@@ -243,10 +237,9 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
      * @public
      */
     function Conference(uuid, name, short, group, cite, link, description, isOpen, isPublished, isActive, hasPresentationPrefs,
-                        groups, start, end, deadline, logo, thumbnail, iOSApp, geo, schedule, info, owners, abstracts, topics, 
+                        groups, start, end, deadline, logo, thumbnail, iOSApp, geo, schedule, info, owners, abstracts, topics,
                         mAbsLeng, mFigs) {
-
-        if (! (this instanceof Conference)) {
+        if (!(this instanceof Conference)) {
             return new Conference(uuid, name, short, group, cite, link, description, isOpen, isPublished, isActive,
                                   hasPresentationPrefs, groups, start, end, deadline, logo, thumbnail, iOSApp,
                                   geo, schedule, info, owners, abstracts, topics, mAbsLeng, mFigs);
@@ -312,12 +305,12 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
 
         self.formatCitation = function(abstract) {
             var year = moment(self.start).year();
-            return abstract.formatAuthorsCitation() + " (" + year + ") " + abstract.title + '. ' + self.name + '.';
+            return abstract.formatAuthorsCitation() + " (" + year + ") " + abstract.title + ". " + self.name + ".";
         };
 
         self.formatCopyright = function(abstract) {
             var year = moment(self.start).year();
-            return "©" + " (" + year + ") " + abstract.formatAuthorsCitation()
+            return "©" + " (" + year + ") " + abstract.formatAuthorsCitation();
         };
 
         self.toObject = function() {
@@ -379,7 +372,6 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
 
             return obj;
         };
-
     }
 
     Conference.fromObject = function(obj) {
@@ -424,8 +416,7 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
      * @public
      */
     function Author(uuid, mail, firstName, middleName, lastName, affiliations) {
-
-        if (! (this instanceof Author)) {
+        if (!(this instanceof Author)) {
             return new Author(uuid, mail, firstName, middleName, lastName, affiliations);
         }
 
@@ -454,7 +445,7 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
         };
 
         self.formatCitation = function() {
-          var res = self.lastName + ' ';
+          var res = self.lastName + " ";
             res += self.makeInitials(self.firstName);
             res += self.makeInitials(self.middleName);
             return res;
@@ -465,9 +456,8 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
                 return "";
             }
 
-           return name.split(' ').map(function(x){ return x[0]; }).join('');
-        }
-
+           return name.split(" ").map(function(x) { return x[0]; }).join("");
+        };
     }
 
     Author.fromObject = function(obj) {
@@ -477,7 +467,6 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
     Author.fromArray = function(array) {
         return Model.fromArray(array, Author.fromObject);
     };
-
 
     /**
      * Observable model for authors.
@@ -494,10 +483,8 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
      * @public
      */
     function ObservableAuthor(uuid, mail, firstName, middleName, lastName, affiliations) {
-
-        if (! (this instanceof ObservableAuthor)) {
-            return new ObservableAuthor(uuid, mail, firstName, middleName,
-                                        lastName, affiliations);
+        if (!(this instanceof ObservableAuthor)) {
+            return new ObservableAuthor(uuid, mail, firstName, middleName, lastName, affiliations);
         }
 
         var self = tools.inherit(this, Model, uuid);
@@ -523,7 +510,6 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
 
             return formatted.sort().join(", ");
         };
-
     }
 
     ObservableAuthor.fromObject = function(obj) {
@@ -548,8 +534,7 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
      * @public
      */
     function Affiliation(uuid, address, country, department, section) {
-
-        if (! (this instanceof  Affiliation)) {
+        if (!(this instanceof  Affiliation)) {
             return new Affiliation(uuid, address, country, department, section);
         }
 
@@ -572,7 +557,6 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
 
             return str;
         };
-
     }
 
     Affiliation.fromObject = function(obj) {
@@ -582,7 +566,6 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
     Affiliation.fromArray = function(array) {
         return Model.fromArray(array, Affiliation.fromObject);
     };
-
 
     /**
      * Obervable model for affiliation
@@ -598,8 +581,7 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
      * @public
      */
     function ObservableAffiliation(uuid, address, country, department, section) {
-
-        if (! (this instanceof  ObservableAffiliation)) {
+        if (!(this instanceof  ObservableAffiliation)) {
             return new ObservableAffiliation(uuid, address, country, department, section);
         }
 
@@ -611,7 +593,7 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
         self.section = ko.observable(section || null);
 
         self.format = function() {
-            var str =(self.department() || "")
+            var str = (self.department() || "")
                 .concat(self.section() ? ", " + self.section() : "")
                 .concat(self.address() ? ", " + self.address() : "")
                 .concat(self.country() ? ", " + self.country() : "");
@@ -622,7 +604,6 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
 
             return str;
         };
-
     }
 
     ObservableAffiliation.fromObject = function(obj) {
@@ -632,8 +613,6 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
     ObservableAffiliation.fromArray = function(array) {
         return Model.fromArray(array, ObservableAffiliation.fromObject);
     };
-    
-    
 
     /**
      * Model for figure.
@@ -647,8 +626,7 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
      * @public
      */
     function Figure(uuid, caption, URL) {
-
-        if (! (this instanceof Figure)) {
+        if (!(this instanceof Figure)) {
             return new Figure(uuid, caption, URL);
         }
 
@@ -656,7 +634,6 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
 
         self.caption = caption || null;
         self.URL = caption || null;
-
     }
 
     Figure.fromObject = function(obj) {
@@ -679,8 +656,7 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
      * @public
      */
     function ObservableFigure(uuid, caption, URL) {
-
-        if (! (this instanceof ObservableFigure)) {
+        if (!(this instanceof ObservableFigure)) {
             return new ObservableFigure(uuid, caption, URL);
         }
 
@@ -688,7 +664,6 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
 
         self.caption = ko.observable(caption || null);
         self.URL = ko.observable(URL || null);
-
     }
 
     ObservableFigure.fromObject = function(obj) {
@@ -712,8 +687,7 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
      * @public
      */
     function Reference(uuid, text, link, doi) {
-
-        if (! (this instanceof Reference)) {
+        if (!(this instanceof Reference)) {
             return new Reference();
         }
 
@@ -725,16 +699,15 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
 
         self.format = function() {
             var text = self.text || self.link;
-            var html = self.link ? '<a target="_blank" href="' + self.link  + '"' + '>' + text + '</a>' : text;
+            var html = self.link ? '<a target="_blank" href="' + self.link  + '">' + text + "</a>" : text;
 
             if (self.doi) {
                 var dx = self.doi;
-                html += ', <a target="_blank" href="http://dx.doi.org/' + dx + '">' + dx + '</a>';
+                html += ', <a target="_blank" href="http://dx.doi.org/' + dx + '">' + dx + "</a>";
             }
 
             return html;
         };
-
     }
 
     Reference.fromObject = function(obj) {
@@ -744,7 +717,6 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
     Reference.fromArray = function(array) {
         return Model.fromArray(array, Reference.fromObject);
     };
-
 
     /**
      * Observable model for reference.
@@ -759,8 +731,7 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
      * @public
      */
     function ObservableReference(uuid, text, link, doi) {
-
-        if (! (this instanceof ObservableReference)) {
+        if (!(this instanceof ObservableReference)) {
             return new ObservableReference();
         }
 
@@ -771,13 +742,12 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
         self.doi = ko.observable(doi || null);
 
         self.format = function() {
-
             var text = self.text() || self.link();
-            var html = self.link() ? '<a target="_blank" href="' + self.link()  + '"' + '>' + text + '</a>' : text;
+            var html = self.link() ? '<a target="_blank" href="' + self.link()  + '">' + text + "</a>" : text;
 
             if (self.doi()) {
                 var dx = self.doi();
-                html += ', <a target="_blank" href="http://dx.doi.org/' + dx + '">' + dx + '</a>';
+                html += ', <a target="_blank" href="http://dx.doi.org/' + dx + '">' + dx + "</a>";
             }
 
             return html;
@@ -791,7 +761,6 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
     ObservableReference.fromArray = function(array) {
         return Model.fromArray(array, ObservableReference.fromObject);
     };
-
 
     /**
      * Model for abstracts.
@@ -820,8 +789,7 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
     function Abstract(uuid, sortId, title, topic, text, doi, conflictOfInterest,
                       acknowledgements, isTalk, reasonForTalk, owners, state, figures,
                       authors, affiliations, references, abstrTypes) {
-
-        if (! (this instanceof Abstract)) {
+        if (!(this instanceof Abstract)) {
             return new Abstract(uuid, sortId, title, topic, text, doi, conflictOfInterest,
                                 acknowledgements, isTalk, reasonForTalk, owners, state,
                                 figures, authors, affiliations, references, abstrTypes);
@@ -846,7 +814,6 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
         self.references = references || [];
         self.abstrTypes = abstrTypes || [];
 
-
         self.paragraphs = function() {
             var para = [];
 
@@ -862,14 +829,14 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
         };
 
         self.doiLink = function() {
-            return self.doi ? 'http://doi.org/' + self.doi : null;
+            return self.doi ? "http://doi.org/" + self.doi : null;
         };
 
         self.formatAuthorsCitation = function() {
             var res = "";
-            for(var i = 0; i < self.authors.length; i++) {
+            for (var i = 0; i < self.authors.length; i++) {
                 if (i != 0) {
-                    res += ', ';
+                    res += ", ";
                 }
                 res += self.authors[i].formatCitation();
             }
@@ -884,7 +851,7 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
                 if (self.hasOwnProperty(prop)) {
                     var value = self[prop];
 
-                    switch(prop) {
+                    switch (prop) {
                         case "authors":
                             obj.authors = [];
                             self.authors.forEach(appendAuthor);
@@ -945,7 +912,7 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
             if (target.hasOwnProperty(prop)) {
                 var value = readProperty(prop, obj);
 
-                switch(prop) {
+                switch (prop) {
                     case "figures":
                         target.figures = Figure.fromArray(value);
                         break;
@@ -976,7 +943,6 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
         return Model.fromArray(array, Abstract.fromObject);
     };
 
-
     /**
      * Observable model for abstracts.
      *
@@ -1004,8 +970,7 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
     function ObservableAbstract(uuid, sortId, title, topic, text, doi, conflictOfInterest,
                                 acknowledgements, isTalk, reasonForTalk, owners, state, figures,
                                 authors, affiliations, references, abstrTypes) {
-
-        if (! (this instanceof ObservableAbstract)) {
+        if (!(this instanceof ObservableAbstract)) {
             return new ObservableAbstract(uuid, sortId, title, topic, text, doi, conflictOfInterest,
                                           acknowledgements, isTalk, reasonForTalk, owners, state,
                                           figures, authors, affiliations, references, abstrTypes);
@@ -1027,13 +992,13 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
         self.authors = ko.observableArray(authors || []);
         self.affiliations = ko.observableArray(affiliations || []);
         self.references = ko.observableArray(references || []);
-        self.abstrTypes = ko.observableArray(abstrTypes||[]);
+        self.abstrTypes = ko.observableArray(abstrTypes || []);
 
         this.isTalk.computed = ko.computed({
-            'read': function() {
+            "read": function() {
                 return self.isTalk().toString();
             },
-            'write': function(val) {
+            "write": function(val) {
                 val = (val === "true");
                 if (!val) {
                     self.reasonForTalk(null);
@@ -1043,13 +1008,12 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
             owner: this
         });
 
-
         self.indexedAuthors = ko.computed(
             function() {
                 var indexed = [];
 
                 self.authors().forEach(function(author, index) {
-                    indexed.push({author: author, index: index})
+                    indexed.push({author: author, index: index});
                 });
 
                 return indexed;
@@ -1075,7 +1039,7 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
                 if (self.hasOwnProperty(prop)) {
                     var value = self[prop];
 
-                    switch(prop) {
+                    switch (prop) {
                         case "title":
                             if (value() !== undefined && value() !== null) {
                                 value(value().trim());
@@ -1198,7 +1162,6 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
 
             return obj;
         };
-
     }
 
     ObservableAbstract.fromObject = function(obj) {
@@ -1209,7 +1172,7 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
             if (target.hasOwnProperty(prop)) {
                 var value = readProperty(prop, obj);
 
-                switch(prop) {
+                switch (prop) {
                     case "figures":
                         target.figures(Figure.fromArray(value));
                         break;
@@ -1247,7 +1210,6 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
         return Model.fromArray(array, ObservableAbstract.fromObject);
     };
 
-
     /**
      * Observable model for user accounts.
      *
@@ -1259,8 +1221,7 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
      * @public
      */
     function ObservableAccount(uuid, mail, fullName, ctime) {
-
-        if (! (this instanceof ObservableAccount)) {
+        if (!(this instanceof ObservableAccount)) {
             return new ObservableAccount(uuid, mail, fullName, ctime);
         }
 
@@ -1272,12 +1233,11 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
 
         self.formatCtime = function() {
             if (self.ctime) {
-                return moment(self.ctime()).format("YY/MM/DD")
+                return moment(self.ctime()).format("YY/MM/DD");
             } else {
-                return ""
+                return "";
             }
-        }
-
+        };
     }
 
     ObservableAccount.fromObject = function(obj) {
@@ -1301,17 +1261,16 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
      * @public
      */
     function ObservableAbstractGroup(uuid, prefix, name, short) {
-    //Why do i not hgave an self ???
-        if (! (this instanceof ObservableAbstractGroup)) {
+        // Why do i not have a self ???
+        if (!(this instanceof ObservableAbstractGroup)) {
             return new ObservableAbstractGroup(uuid, prefix, name, short);
         }
 
         var self = tools.inherit(this, Model, uuid);
 
-        self.prefix= ko.observable(prefix || null);
+        self.prefix = ko.observable(prefix || null);
         self.name = ko.observable(name || null);
         self.short = ko.observable(short || null);
-
     }
 
     ObservableAbstractGroup.fromObject = function(obj) {
@@ -1337,7 +1296,6 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
      * @public
      */
     function SchedulerEvent (id, text, startDate, endDate, baseEvent) {
-
         if (!(this instanceof SchedulerEvent)) {
             return new SchedulerEvent(id, text, startDate, endDate, baseEvent);
         }
@@ -1349,7 +1307,8 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
         self.start_date = startDate || null;
         self.end_date = endDate || null;
         self.baseEvent = baseEvent || null;
-        self.parentEvent = null; // used for split events to easily collapse them into the parent
+        // used for split events to easily collapse them into the parent
+        self.parentEvent = null;
 
         self.isTrack = function () {
             return self.baseEvent.hasOwnProperty("events");
@@ -1388,12 +1347,9 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
             });
             return splitEvents;
         };
-
-    };
-
+    }
 
     function Track (title, subtitle, chair, events) {
-
         if (!(this instanceof Track)) {
             return new Track(title, subtitle, chair, events);
         }
@@ -1420,11 +1376,13 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
                       splitEvents.push(event);
                   }
               });
-              if (splitEvents.length > 0) { // do not process empty dates
+              // do not process empty dates
+              if (splitEvents.length > 0) {
                   subtracks.push(new Track(self.title, self.subtitle, self.chair, splitEvents));
               }
-              splitDate = new Date(splitDate.getTime() + 24*60*60*1000); // switch to the next day
-          };
+              // switch to the next day
+              splitDate = new Date(splitDate.getTime() + 24 * 60 * 60 * 1000);
+          }
           return subtracks;
         };
 
@@ -1457,11 +1415,9 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
 
             return endingDate;
         };
-
-    };
+    }
 
     function Session (title, subtitle, tracks) {
-
         if (!(this instanceof Session)) {
             return new Session(title, subtitle, tracks);
         }
@@ -1494,11 +1450,13 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
                         splitTracks.push(track);
                     }
                 });
-                if (splitTracks.length > 0) { // do not process empty dates
+                // do not process empty dates
+                if (splitTracks.length > 0) {
                     subsessions.push(new Session(self.title, self.subtitle, splitTracks));
                 }
-                splitDate = new Date(splitDate.getTime() + 24*60*60*1000); // switch to the next day
-            };
+                // switch to the next day
+                splitDate = new Date(splitDate.getTime() + 24 * 60 * 60 * 1000);
+            }
             return subsessions;
         };
 
@@ -1531,11 +1489,9 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
 
             return endingDate;
         };
-
-    };
+    }
 
     function Event (title, subtitle, start, end, date, location, authors, type, abstract) {
-
         if (!(this instanceof Event)) {
             return new Event(title, subtitle, start, end, date, location, authors, type, abstract);
         }
@@ -1567,13 +1523,13 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
             // format year-month-day
             var ymd = self.date.split("-");
             // format hour:minute
-            var time = ["23","59"];
+            var time = ["23", "59"];
             if (self.end && self.end.length > 0) {
                 time = self.end.split(":");
             }
             return new Date(parseInt(ymd[0]), parseInt(ymd[1]) - 1, parseInt(ymd[2]), parseInt(time[0]), parseInt(time[1]));
         };
-    };
+    }
 
     /*
      * Create a DHTMLX Scheduler event from an Event, Track or Session.
@@ -1658,7 +1614,6 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
      * @public
      */
     function Schedule (content) {
-
         if (!(this instanceof Schedule)) {
             return new Schedule(content);
         }
@@ -1676,7 +1631,7 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
                 if ((date.getDate() == start.getDate()
                         && date.getMonth() == start.getMonth()
                         && date.getFullYear() == start.getFullYear())
-                    ||(date.getDate() == end.getDate()
+                    || (date.getDate() == end.getDate()
                         && date.getMonth() == end.getMonth()
                         && date.getFullYear() == end.getFullYear())) {
                     dailyEvents.push(event);
@@ -1753,8 +1708,7 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
 
             return endingDate;
         };
-
-    };
+    }
 
     /*
      * Check whether the tow dates are on the same date.
@@ -1789,27 +1743,28 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
      * I guess it is ok to use this term instead.
      */
     Schedule.fromObject = function (scheduleObject) {
-
         var content = [];
 
-        scheduleObject.forEach( function(entry) {
-            if (entry.hasOwnProperty("tracks")) { // only sessions have this property
+        scheduleObject.forEach(function(entry) {
+            if (entry.hasOwnProperty("tracks")) {
+                // only sessions have this property
                 var session = Session.fromObject(entry);
                 session.splitByDays().forEach(function (s) {
                     content.push(s);
                 });
-            } else if (entry.hasOwnProperty("events")) { // only tracks have this property
+            } else if (entry.hasOwnProperty("events")) {
+                // only tracks have this property
                 var track = Track.fromObject(entry);
                 track.splitByDays().forEach(function (t) {
                     content.push(t);
                 });
-            } else { // all the rest are simply events
+            } else {
+                // all the rest are simply events
                 content.push(Event.fromObject(entry));
             }
         });
 
         return new Schedule(content);
-
     };
 
     return {
@@ -1826,12 +1781,11 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
         ObservableAbstract: ObservableAbstract,
         ObservableAccount: ObservableAccount,
         AbstractGroup: AbstractGroup,
-        ObservableAbstractGroup:ObservableAbstractGroup,
+        ObservableAbstractGroup: ObservableAbstractGroup,
         Schedule: Schedule,
         Event: Event,
         Track: Track,
         Session: Session,
         SchedulerEvent: SchedulerEvent
     };
-
 });

--- a/app/assets/javascripts/lib/models.js
+++ b/app/assets/javascripts/lib/models.js
@@ -329,6 +329,17 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
                     var value = self[prop];
                     var plain = null;
 
+                    if (prop === "topics" && value() !== null && value !== undefined) {
+                        var cleanTopics = [];
+                        value().forEach(function (model) {
+                            var curr = model.trim();
+                            if (curr.length > 0) {
+                                cleanTopics.push(curr);
+                            }
+                        });
+                        value(cleanTopics);
+                    }
+
                     if (tools.type(value) !== "function") {
                         plain = value;
                     } else if (tools.functionName(value) === "observable") {

--- a/app/assets/javascripts/lib/models.js
+++ b/app/assets/javascripts/lib/models.js
@@ -329,6 +329,12 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
                     var value = self[prop];
                     var plain = null;
 
+                    // Trim whitespaces before saving
+                    var trimValueProperties = ["name", "short", "cite", "group", "link", "description"];
+                    if (trimValueProperties.includes(prop) && value() !== null && value !== undefined) {
+                        value(value().trim());
+                    }
+
                     if (prop === "topics" && value() !== null && value !== undefined) {
                         var cleanTopics = [];
                         value().forEach(function (model) {

--- a/app/assets/javascripts/lib/models.js
+++ b/app/assets/javascripts/lib/models.js
@@ -1051,6 +1051,24 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
                     var value = self[prop];
 
                     switch(prop) {
+                        case "title":
+                            if (value() !== undefined && value() !== null) {
+                                value(value().trim());
+                            }
+                            obj[prop] = toType(value());
+                            break;
+                        case "text":
+                            if (value() !== undefined && value() !== null) {
+                                value(value().trim());
+                            }
+                            obj[prop] = toType(value());
+                            break;
+                        case "acknowledgements":
+                            if (value() !== undefined && value() !== null) {
+                                value(value().trim());
+                            }
+                            obj[prop] = toType(value());
+                            break;
                         case "authors":
                             obj.authors = [];
                             self.authors().forEach(appendAuthor);
@@ -1082,14 +1100,51 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
             }
 
             function appendAuthor(model) {
+                // Post processing, remove all leading and trailing whitespaces.
+                if (model.firstName() !== null && model.firstName() !== undefined) {
+                    model.firstName(model.firstName().trim());
+                }
+                if (model.lastName() !== null && model.lastName() !== undefined) {
+                    model.lastName(model.lastName().trim());
+                }
+                if (model.middleName() !== null && model.middleName() !== undefined) {
+                    model.middleName(model.middleName().trim());
+                }
+                if (model.mail() !== null && model.mail() !== undefined) {
+                    model.mail(model.mail().trim());
+                }
                 obj.authors.push(model.toObject());
             }
 
             function appendAffiliation(model) {
+                // Post processing, remove all leading and trailing whitespaces.
+                if (model.address() !== null && model.address() !== undefined) {
+                    model.address(model.address().trim());
+                }
+                if (model.department() !== null && model.department() !== undefined) {
+                    model.department(model.department().trim());
+                }
+                if (model.country() !== null && model.country() !== undefined) {
+                    model.country(model.country().trim());
+                }
+                if (model.section() !== null && model.section() !== undefined) {
+                    model.section(model.section().trim());
+                }
                 obj.affiliations.push(model.toObject());
             }
 
             function appendReference(model) {
+                // Post processing, remove all leading and trailing whitespaces.
+                if (model.text() !== null && model.text() !== undefined) {
+                    model.text(model.text().trim());
+                }
+                if (model.link() !== null && model.link() !== undefined) {
+                    model.link(model.link().trim());
+                }
+                if (model.doi() !== null && model.doi() !== undefined) {
+                    model.doi(model.doi().trim());
+                }
+
                 // Post process doi. Remove any leading doi link parts that hinder rendering later on.
                 var doiValue = model.doi();
 

--- a/app/assets/javascripts/lib/models.js
+++ b/app/assets/javascripts/lib/models.js
@@ -310,7 +310,7 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
 
         self.formatCopyright = function(abstract) {
             var year = moment(self.start).year();
-            return "©" + " (" + year + ") " + abstract.formatAuthorsCitation();
+            return "© (" + year + ") " + abstract.formatAuthorsCitation();
         };
 
         self.toObject = function() {
@@ -818,7 +818,7 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
             var para = [];
 
             if (self.text) {
-                para = self.text.split('\n');
+                para = self.text.split("\n");
             }
 
             return para;
@@ -899,9 +899,9 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
             return obj;
         };
 
-    self.hasTypeWuuid = function (uuid) {
-        return true;
-        }
+        self.hasTypeWuuid = function (uuid) {
+            return true;
+        };
     }
 
     Abstract.fromObject = function(obj) {
@@ -1025,7 +1025,7 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
             var para = [];
 
             if (self.text()) {
-                para = self.text().split('\n');
+                para = self.text().split("\n");
             }
 
             return para;

--- a/app/assets/javascripts/lib/models.js
+++ b/app/assets/javascripts/lib/models.js
@@ -366,6 +366,14 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
             }
 
             function appendGroup(model) {
+                // Cleanup leading and trailing whitespaces
+                if (model.short() !== null && model.short() !== undefined) {
+                    model.short(model.short().trim());
+                }
+                if (model.name() !== null && model.name() !== undefined) {
+                    model.name(model.name().trim());
+                }
+
                 obj.groups.push(model.toObject());
             }
 

--- a/app/assets/javascripts/lib/msg.js
+++ b/app/assets/javascripts/lib/msg.js
@@ -3,38 +3,35 @@
  * @module {lib/msg}
  */
 define(["lib/tools", "knockout"], function(tools, ko) {
-
     function MessageBox() {
-
         if (tools.isGlobalOrUndefined(this)) {
             return new MessageBox();
         }
 
         var self = this;
 
-        var success = 'success',
-            info = 'info',
-            warning = 'warning',
-            danger = 'danger',
+        var success = "success",
+            info = "info",
+            warning = "warning",
+            danger = "danger",
             levels = [success, info, warning, danger],
             defaultTimeout = 3000;
 
         self.message = ko.observable(null);
 
         self.setMessage = function(level, text, description, timeout) {
-
             if (levels.indexOf(level) < 0) {
                 throw "Not a valid level";
             }
 
             if (text) {
-                self.message({message: text, level: 'callout-' + level, desc: description, close: self.clearMessage});
+                self.message({message: text, level: "callout-" + level, desc: description, close: self.clearMessage});
             } else {
                 self.clearMessage();
             }
 
             if (timeout) {
-                var t = tools.type(timeout) === 'number' ? timeout : defaultTimeout;
+                var t = tools.type(timeout) === "number" ? timeout : defaultTimeout;
                 setTimeout(self.clearMessage, t);
             }
         };
@@ -70,11 +67,9 @@ define(["lib/tools", "knockout"], function(tools, ko) {
         };
 
         self.setOk = self.setSuccess;
-
     }
 
     return {
         MessageBox: MessageBox
     };
-
 });

--- a/app/assets/javascripts/lib/multi.js
+++ b/app/assets/javascripts/lib/multi.js
@@ -5,10 +5,10 @@ define(function() {
     "use strict";
 
     // some constants
-    var sep = '\r\n',
-        sepEnd = '\r\n\r\n',
-        stdContentType = 'text/plain',
-        binContentType = 'application/octet-stream';
+    var sep = "\r\n",
+        sepEnd = "\r\n\r\n",
+        stdContentType = "text/plain",
+        binContentType = "application/octet-stream";
 
     // helper function
     function createBoundary() {
@@ -32,14 +32,13 @@ define(function() {
      * @public
      */
     function MultiPart() {
-
-        if (! (this instanceof MultiPart)) {
+        if (!(this instanceof MultiPart)) {
             return new MultiPart();
         }
 
         var self = this;
         var bound = createBoundary(),
-            mpContentType = 'multipart/form-data; boundary=' + bound,
+            mpContentType = "multipart/form-data; boundary=" + bound,
             body = "";
 
         /**
@@ -58,7 +57,7 @@ define(function() {
             body += 'Content-Disposition: form-data; name="' + name + '"' + sepEnd;
 
             body += text + sep;
-        }
+        };
 
         /**
          * Append file data.
@@ -73,8 +72,8 @@ define(function() {
 
             body += bound + sep;
             body += 'Content-Disposition: form-data; name="' + name + '"; filename="' + fileName + '"' + sep;
-            body += 'Content-Length: ' + data.length + sep;
-            body += 'Content-Type: ' + contentType + sepEnd;
+            body += "Content-Length: " + data.length + sep;
+            body += "Content-Type: " + contentType + sepEnd;
 
             body += data + sep;
         };
@@ -89,7 +88,6 @@ define(function() {
          * @param {Function} [error]        Error callback.
          */
         self.appendInput = function(name, input, success, error) {
-
             if (!FileReader) {
                 throw "Browser does not support FileReader";
             }
@@ -115,15 +113,14 @@ define(function() {
                 return function(e) {
                     self.appendFile(name, f.name, e.target.result, f.type);
                     if (success) success(self, f, "Loaded file " + f.name);
-                }
+                };
             }
 
             function onerror(f) {
                 return function(e) {
                     if (error) error(self, f, "Unable to read file: " + f.name);
-                }
+                };
             }
-
         };
 
         /**
@@ -134,7 +131,6 @@ define(function() {
         self.contentType = function() {
             return mpContentType;
         };
-
 
         /**
          * Get the request body.
@@ -151,14 +147,11 @@ define(function() {
          * @returns {string} Header and request body as string.
          */
         self.all = function() {
-            return 'Content-Type: ' + self.contentType() + sepEnd + self.body();
+            return "Content-Type: " + self.contentType() + sepEnd + self.body();
         };
-
     }
 
     return {
         MultiPart: MultiPart
-    }
-
-
+    };
 });

--- a/app/assets/javascripts/lib/offline.js
+++ b/app/assets/javascripts/lib/offline.js
@@ -12,24 +12,21 @@ define([], function() {
      * local storage will be searched by the specified fallback key.
      */
     function requestJSON (key, url, successFunction, failHandler) {
-        $.getJSON(url, successFunction).fail(function (keyHandover, urlHandover
-                                                       ,successFunctionHandover,
+        $.getJSON(url, successFunction).fail(function (keyHandover, urlHandover,
+                                                       successFunctionHandover,
                                                        failHandlerHandover) {
             return function (jqxhr, textStatus, error) {
-                console.log("Server request of " + urlHandover + " failed. Try loading local " +
-                    "storage entry " + keyHandover + ".");
                 var stored = localStorage.getItem(keyHandover);
                 if (stored !== null && stored !== undefined) {
                     successFunctionHandover(JSON.parse(stored));
                 } else {
                     failHandlerHandover(jqxhr, textStatus, error);
                 }
-            }
+            };
         }(key, url, successFunction, failHandler));
     }
 
     return {
         requestJSON: requestJSON
     };
-
 });

--- a/app/assets/javascripts/lib/owned.js
+++ b/app/assets/javascripts/lib/owned.js
@@ -3,9 +3,7 @@
  * @module {lib/owned}
  */
 define(["lib/tools", "lib/models", "knockout"], function(tools, models, ko) {
-
     function Owned() {
-
         if (tools.isGlobalOrUndefined(this)) {
             return new Owned();
         }
@@ -19,7 +17,7 @@ define(["lib/tools", "lib/models", "knockout"], function(tools, models, ko) {
             console.log("[owned.js] Unhandled " + lvl + ": " + txt);
         };
 
-        //private stuff
+        // private stuff
         function ioFailHandler_(jqxhr, textStatus, error) {
             var err = textStatus + ", " + error;
             self.ownersErrorHandler("danger", "Error while fetching data from server: <br>" + err);
@@ -30,13 +28,13 @@ define(["lib/tools", "lib/models", "knockout"], function(tools, models, ko) {
                 var owners = models.ObservableAccount.fromArray(ownersAsJson);
                 self.owners(owners);
 
-                if(andThenDo) {
+                if (andThenDo) {
                     andThenDo();
                 }
-            }
+            };
         }
 
-        //public stuff
+        // public stuff
         self.setupOwners = function(ownersURL, errorHandler) {
             self.ownersURL = ownersURL;
             self.ownersErrorHandler = errorHandler;
@@ -44,23 +42,23 @@ define(["lib/tools", "lib/models", "knockout"], function(tools, models, ko) {
 
         self.loadOwnersData = function(andThenDo) {
             if (self.ownersURL !== null) {
-                console.log("loadOwners::");
                 $.getJSON(self.ownersURL, onOwnersData(andThenDo)).fail(ioFailHandler_);
             }
         };
 
         self.addOwner = function() {
-            var mailInput = $('#ownedEmail');
+            var mailInput = $("#ownedEmail");
             var email = mailInput.val();
 
             var ownersLength = self.owners().length;
             for (var i = 0; i < ownersLength; i++) {
-                if (self.owners()[i].mail() == email) {
-                    return; // if we want to add an existing one, don't do anything
+                if (self.owners()[i].mail() === email) {
+                    // if we want to add an existing one, don't do anything
+                    return;
                 }
             }
 
-            var userURL ="/api/users?email=" + email;
+            var userURL = "/api/users?email=" + email;
             $.getJSON(userURL, onValidateEmail).fail(self.ioFailHandler);
 
             function onValidateEmail(accountsAsJson) {
@@ -80,7 +78,6 @@ define(["lib/tools", "lib/models", "knockout"], function(tools, models, ko) {
         };
 
         self.saveOwner = function() {
-
             var data = $.map(self.owners(), function(item) { return item.toJSON(); });
             $.ajax(self.ownersURL, {
                 data: "[" + data.join(",") + "]",
@@ -92,9 +89,7 @@ define(["lib/tools", "lib/models", "knockout"], function(tools, models, ko) {
         };
     }
 
-
     return {
         Owned: Owned
     };
-
 });

--- a/app/assets/javascripts/lib/tools.js
+++ b/app/assets/javascripts/lib/tools.js
@@ -16,7 +16,7 @@ define(function() {
         var result = true;
 
         if (obj !== undefined) {
-            result = new Function('return this;')() === obj;
+            result = new Function("return this;")() === obj;
         }
 
         return result;
@@ -60,9 +60,7 @@ define(function() {
      * @public
      */
     function inherit(obj, superclass) {
-
         if (superclass instanceof Function) {
-
             var param;
             if (arguments.length > 2) {
                 param = Array.prototype.slice.call(arguments, 2);
@@ -85,27 +83,26 @@ define(function() {
      * @public
      */
     function type(obj) {
-
         var str,
             typ;
 
         if (obj === null) {
-            return 'null';
+            return "null";
         }
 
         if (obj && (obj.nodeType === 1 || obj.nodeType === 9)) {
-            return 'element';
+            return "element";
         }
 
         str = Object.prototype.toString.call(obj);
         typ = str.match(/\[object (.*?)\]/)[1].toLowerCase();
 
-        if (typ === 'number') {
+        if (typ === "number") {
             if (isNaN(obj)) {
-                return 'nan';
+                return "nan";
             }
             if (!isFinite(obj)) {
-                return 'infinity';
+                return "infinity";
             }
         }
 
@@ -120,8 +117,7 @@ define(function() {
      * @returns {string} The modified string.
      * @public
      */
-    function toUnderscore(str){
-
+    function toUnderscore(str) {
         function substitute(char) {
             return "_" + char.toLowerCase();
         }
@@ -138,7 +134,6 @@ define(function() {
      * @public
      */
     function toCamelCase(str) {
-
         function substitute(char) {
              return char.toUpperCase();
         }
@@ -178,21 +173,18 @@ define(function() {
      * @public
      */
     function formParse(dom) {
-
         var match,
             pattern = /^(\w+)($|\[\]|\[(\w+)\]$)/,
             data = {},
             inputs = dom.find("input, textarea, select");
 
         inputs.each(function() {
-
             var input = $(this),
                 type  = input.attr("type").toLowerCase(),
                 name  = input.attr("name").toLowerCase(),
                 val   = input.val();
 
             if (type !== "submit") {
-
                 match = pattern.exec(name);
 
                 if (!match) {
@@ -214,7 +206,6 @@ define(function() {
                     data[name][match[3]] = val;
                 }
             }
-
         });
 
         return data;
@@ -229,7 +220,7 @@ define(function() {
      * @public
      */
     function functionName(fn) {
-        if (type(fn) !== 'function') {
+        if (type(fn) !== "function") {
             return null;
         }
 
@@ -241,7 +232,6 @@ define(function() {
         }
     }
 
-
     return {
         isGlobalOrUndefined: isGlobalOrUndefined,
         hiddenData: hiddenData,
@@ -252,5 +242,4 @@ define(function() {
         formParse: formParse,
         functionName: functionName
     };
-
 });

--- a/app/assets/javascripts/lib/validate.js
+++ b/app/assets/javascripts/lib/validate.js
@@ -39,7 +39,7 @@ define(["lib/tools"], function (tools) {
             abstract,
             must("title", notNothing, "The abstract has no title"),
             should("abstrTypes", notEmpty, "No presentation type selected"),
-            should("authors", notEmpty, "No authors are defined for this abstract"),            
+            should("authors", notEmpty, "No authors are defined for this abstract"),
             should("authors", useAllAffiliations(getVal(abstract, "affiliations")), "Some affiliations are not used"),
             should("text", notNothing, "The abstract contains no text"),
             should("topic", notNothing, "No topic selected for the abstract")
@@ -93,8 +93,7 @@ define(["lib/tools"], function (tools) {
      * @public
      */
     function Result(errors, warnings) {
-
-        if (! (this instanceof  Result)) {
+        if (!(this instanceof  Result)) {
             return new Result(errors, warnings);
         }
 
@@ -153,7 +152,7 @@ define(["lib/tools"], function (tools) {
         return function(obj) {
             var val = getVal(obj, field);
 
-            if (! test(val)) {
+            if (!test(val)) {
                 return Result(msg);
             } else {
                 return Result();
@@ -175,7 +174,7 @@ define(["lib/tools"], function (tools) {
         return function(obj) {
             var val = getVal(obj, field);
 
-            if (! test(val)) {
+            if (!test(val)) {
                 return Result(null, msg);
             } else {
                 return Result();
@@ -218,24 +217,22 @@ define(["lib/tools"], function (tools) {
      *                     list as first and only argument.
      */
     function useAllAffiliations(affiliations) {
-
-        var positions = affiliations.map( function(_, index) { return index; } );
+        var positions = affiliations.map(function(_, index) {
+            return index;
+        });
 
         return function(authors) {
             var used = positions.filter(function(pos) {
                 return authors.some(function(author) {
-                    var otherPositions = getVal(author, "affiliations")
+                    var otherPositions = getVal(author, "affiliations");
                     return otherPositions.indexOf(pos) >= 0;
-                })
+                });
             });
             return used.length === positions.length;
-        }
+        };
     }
 
-    //
     // Helper
-    //
-
     function getVal(obj, field) {
         var val = obj[field];
 
@@ -246,12 +243,9 @@ define(["lib/tools"], function (tools) {
         return val;
     }
 
-    //
     // Create and return the module
-    //
-
     return {
         author: validateAuthor,
         abstract: validateAbstract
-    }
+    };
 });

--- a/app/assets/javascripts/locations.js
+++ b/app/assets/javascripts/locations.js
@@ -3,7 +3,6 @@ require(["lib/models", "lib/tools", "lib/leaflet/leaflet", "lib/msg", "lib/astat
     "use strict";
 
     function LocationsViewModel(confId, mapType) {
-
         if (!(this instanceof LocationsViewModel)) {
             return new LocationsViewModel(confId, mapType);
         }
@@ -16,12 +15,12 @@ require(["lib/models", "lib/tools", "lib/leaflet/leaflet", "lib/msg", "lib/astat
         self.geoContent = ko.observable(null);
         self.stateLog = ko.observable(null);
 
-        //observables as iterative list
-
+        // Observables as iterative list
         self.init = function() {
             self.loadConference(confId);
             ko.applyBindings(window.viewer);
-            MathJax.Hub.Configured(); //start MathJax
+            // start MathJax
+            MathJax.Hub.Configured();
         };
 
         self.ioFailHandler = function(jqxhr, textStatus, error) {
@@ -29,7 +28,8 @@ require(["lib/models", "lib/tools", "lib/leaflet/leaflet", "lib/msg", "lib/astat
         };
 
         self.loadConference = function(confId) {
-            var confUrl = "/api/conferences/" + confId; // we should be reading this from the conference
+            // we should be reading this from the conference
+            var confUrl = "/api/conferences/" + confId;
 
             offline.requestJSON(confId, confUrl, onConferenceData, self.ioFailHandler);
 
@@ -39,98 +39,83 @@ require(["lib/models", "lib/tools", "lib/leaflet/leaflet", "lib/msg", "lib/astat
                 offline.requestJSON(conf.uuid + "geo", self.conference().geo, onGeoData, self.ioFailHandler);
 
                 function onGeoData(geojson) {
-                    //depending on whether locations or floor plan page
-                    if (self.mapType == "locations") {
-                        //map
-                        $('#map-div').height(0.75*$('#map-div').width());
-                        var confmap = L.map('map-div');
-                        L.tileLayer('https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token={accessToken}', {
+                    // depending on whether locations or floor plan page
+                    if (self.mapType === "locations") {
+                        $("#map-div").height(0.75 * $("#map-div").width());
+                        var confmap = L.map("map-div");
+                        L.tileLayer("https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token={accessToken}", {
                             attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, <a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery © <a href="https://www.mapbox.com/">Mapbox</a>',
                             maxZoom: 20,
-                            id: 'mapbox.streets',
-                            accessToken: 'pk.eyJ1IjoiZ25vZGUiLCJhIjoiY2prOGFnbzY2MWlmNzN3bzRhY205N2oxZCJ9.-j7b1aziK9nUNjgHQh0ojw'
+                            id: "mapbox.streets",
+                            accessToken: "pk.eyJ1IjoiZ25vZGUiLCJhIjoiY2prOGFnbzY2MWlmNzN3bzRhY205N2oxZCJ9.-j7b1aziK9nUNjgHQh0ojw"
                         }).addTo(confmap);
-                        var texts = '';
+                        var texts = "";
 
                         for (var i = 0; i < geojson.length; i++) {
-                            //get map coordinates
-                            var coords = [geojson[i].point.lat,geojson[i].point.long]
-                            texts += geojson[i].name + '\n';
-                            //set view only once
-                            if (i == 0) {
+                            // get map coordinates
+                            var coords = [geojson[i].point.lat, geojson[i].point.long];
+                            texts += geojson[i].name + "\n";
+                            // set view only once
+                            if (i === 0) {
                                 confmap.setView(coords, 13);
                             }
-                            //add markers and descriptions
+                            // add markers and descriptions
                             var marker = L.marker(coords).addTo(confmap);
-                            marker.bindPopup('<b>' + geojson[i].name + '</b><br>' + geojson[i].description).openPopup();
+                            marker.bindPopup("<b>" + geojson[i].name + "</b><br>" + geojson[i].description).openPopup();
                         }
-                    } else if (self.mapType == "floorplans") {
-                        //load all floorplans on one page
+                    } else if (self.mapType === "floorplans") {
+                        // load all floorplans on one page
                         for (var i = 0; i < geojson.length; i++) {
-                            //load floorplans, if they're included
-                            if(geojson[i].floorplans) {
-                                $('#floorplans-wrap').append('<h2>' + geojson[i].name + '</h2><p>' + geojson[i].description + '</p>');
+                            // load floorplans, if they're included
+                            if (geojson[i].floorplans) {
+                                $("#floorplans-wrap").append("<h2>" + geojson[i].name + "</h2><p>" + geojson[i].description + "</p>");
 
-                                for(var j=0; j<geojson[i].floorplans.length; j++) {
-
-                                    //create image in order to get actual image dimensions cross browser
+                                for (var j = 0; j < geojson[i].floorplans.length; j++) {
+                                    // create image in order to get actual image dimensions cross browser
                                     var img = new Image();
                                     img.src = geojson[i].floorplans[j];
                                     img.onload = handleLoad;
 
-
-                                    //possible to incorporate rooms with coordinates just as above,
-                                    //just be sure to use right coordinate system (cf. leaflet page)
-                                    //and mapping probably needed for room number vs. location
+                                    // possible to incorporate rooms with coordinates just as above,
+                                    // just be sure to use right coordinate system (cf. leaflet page)
+                                    // and mapping probably needed for room number vs. location
                                 }
                             }
                         }
                     }
-                    //add addresses as text
-                    //self.geoContent(texts);
 
                     function handleLoad(response) {
-
-                        $('#floorplans-wrap').append('<div id="floorplan-div-' + i + + j + '" class="floorplan-divs" style="margin-bottom: 1em;"></div>');
+                        $("#floorplans-wrap").append('<div id="floorplan-div-' + i + j + '" class="floorplan-divs" style="margin-bottom: 1em;"></div>');
 
                         // Get accurate measurements from that.
                         var nw = img.width;
                         var nh = img.height;
 
-                        console.log(nw+' '+nh+' '+img.src);
-                        var floor = L.map('floorplan-div-' + i + j, {
+                        var floor = L.map("floorplan-div-" + i + j, {
                             crs: L.CRS.Simple,
                             minZoom: 0
                         });
 
-                        if(nh>nw){
-                            $('#floorplan-div-'+i+j).height($('#floorplan-div-'+i+j).width());
-                            $('#floorplan-div-'+i+j).width(nw/nh*$('#floorplan-div-'+i+j).height());
-                        }else{
-                            $('#floorplan-div-'+i+j).height(nh/nw*$('#floorplan-div-'+i+j).width());
+                        if (nh > nw) {
+                            $("#floorplan-div-" + i + j).height($("#floorplan-div-" + i + j).width());
+                            $("#floorplan-div-" + i + j).width(nw / nh * $("#floorplan-div-" + i + j).height());
+                        } else {
+                            $("#floorplan-div-" + i + j).height(nh / nw * $("#floorplan-div-" + i + j).width());
                         }
 
-                        var bounds  = [[0, 0], [$('#floorplan-div-'+i+j).height(), $('#floorplan-div-'+i+j).width()]];
+                        var bounds  = [[0, 0], [$("#floorplan-div-" + i + j).height(), $("#floorplan-div-" + i + j).width()]];
                         var image = L.imageOverlay(img.src, bounds).addTo(floor);
                         floor.fitBounds(bounds);
                     }
-
                 }
             }
-
         };
-
     }
 
     $(document).ready(function() {
-
         var data = tools.hiddenData();
-
-        window.viewer = LocationsViewModel(data["conferenceUuid"],data["mapType"]);
-
+        window.viewer = LocationsViewModel(data["conferenceUuid"], data["mapType"]);
         window.viewer.init();
-
     });
-
 });
 });

--- a/app/assets/javascripts/mob_abstract-list.js
+++ b/app/assets/javascripts/mob_abstract-list.js
@@ -2,7 +2,6 @@ require(["main"], function () {
 require(["lib/models", "lib/tools", "knockout", "sammy"], function(models, tools, ko, Sammy) {
     "use strict";
 
-
     /**
      * AbstractList view model.
      *
@@ -12,8 +11,7 @@ require(["lib/models", "lib/tools", "knockout", "sammy"], function(models, tools
      * @constructor
      */
     function AbstractListViewModel(confId) {
-
-        if (! (this instanceof AbstractListViewModel)) {
+        if (!(this instanceof AbstractListViewModel)) {
             return new AbstractListViewModel(confId);
         }
 
@@ -26,24 +24,24 @@ require(["lib/models", "lib/tools", "knockout", "sammy"], function(models, tools
         self.groups = ko.observableArray(null);
         self.error = ko.observable(false);
 
-        //maps for uuid -> abstract, doi -> abstract,
-        //         neighbours -> prev & next of current list
+        // maps for uuid -> abstract, doi -> abstract,
+        //          neighbours -> prev & next of current list
         self.uuidMap = {};
         self.neighbours = {};
 
-
         self.init = function() {
             ko.applyBindings(window.abstractList);
-            MathJax.Hub.Configured(); //start MathJax
+            // start MathJax
+            MathJax.Hub.Configured();
         };
 
         self.setError = function(level, text) {
-            self.error({message: text, level: 'alert-' + level});
+            self.error({message: text, level: "alert-" + level});
             self.isLoading(false);
         };
 
         self.makeLink = function(abstract) {
-            return '#' + '/uuid/' + abstract.uuid;
+            return "#/uuid/" + abstract.uuid;
         };
 
         self.getGroupById = function(groupid) {
@@ -78,24 +76,20 @@ require(["lib/models", "lib/tools", "knockout", "sammy"], function(models, tools
             return prefix + "&nbsp;" + aid;
         };
 
-
         self.selectAbstract = function(abstract) {
-            console.log("Selecting abstract " + abstract.uuid + " " + abstract.toString());
             window.location = self.makeLink(abstract);
         };
 
         self.showAbstract = function(abstract) {
-
             self.abstracts(null);
             self.selectedAbstract(abstract);
-            document.title = abstract.title; //FIXME add conference
-            MathJax.Hub.Queue(["Typeset",MathJax.Hub]); //re-render equations
+            document.title = abstract.title;
+            // re-render equations
+            MathJax.Hub.Queue(["Typeset", MathJax.Hub]);
         };
 
         self.showAbstractByUUID = function(uuid) {
-
-            if(!uuid in self.uuidMap) {
-                console.log("Warning uuid to show not in map");
+            if (!uuid in self.uuidMap) {
                 return;
             }
 
@@ -103,33 +97,23 @@ require(["lib/models", "lib/tools", "knockout", "sammy"], function(models, tools
         };
 
         self.activateGroup = function(groupId) {
-
         };
 
-
         self.showAbstractsByGroup = function(groupId) {
-
-            console.log("groupid" + groupId);
-
             var selGroup = null;
             for (var i = 0; i < self.groups().length; i++) {
                 var curGroup = self.groups()[i];
                 if (curGroup.short === groupId) {
                     selGroup = curGroup;
-                    //we don't break here because we want to set
-                    //all the groups 'state' member
-
+                    // we don't break here because we want to set all the groups 'state' member
                     curGroup.state("active");
                 } else {
                     curGroup.state("");
                 }
             }
 
-
-
             if (selGroup === null) {
-                self.setError("danger", "Internal error [group selection]!")
-                console.log("Error invalid group selected");
+                self.setError("danger", "Internal error [group selection]!");
                 self.showAbstractList([]);
                 return;
             }
@@ -155,9 +139,7 @@ require(["lib/models", "lib/tools", "knockout", "sammy"], function(models, tools
             self.neighbours = self.makeNeighboursMap(theList);
         };
 
-
         self.buildGroups = function() {
-
             function mkGroup(_prefix, _name, _short) {
                 return {
                     prefix: _prefix,
@@ -179,9 +161,10 @@ require(["lib/models", "lib/tools", "knockout", "sammy"], function(models, tools
           self.groups(theGroups);
         };
 
-        //map related stuff
+        // map related stuff
         self.buildMaps = function() {
-            self.uuidMap = {}; //empty the map
+            // Empty map
+            self.uuidMap = {};
             for (var i = 0; i < self.abstractsData.length; i++) {
                 var currentAbstract = self.abstractsData[i];
                 self.uuidMap[currentAbstract.uuid] = currentAbstract;
@@ -195,11 +178,11 @@ require(["lib/models", "lib/tools", "knockout", "sammy"], function(models, tools
                 return theMap;
             }
 
-            for(var i = 0; i < objs.length; i++) {
+            for (var i = 0; i < objs.length; i++) {
                 theMap[objs[i].uuid] = {
-                    prev: i > 0 ? self.makeLink(objs[i-1]): null,
-                    next: i + 1 != objs.length ? self.makeLink(objs[i+1]) : null
-                }
+                    prev: i > 0 ? self.makeLink(objs[i - 1]) : null,
+                    next: i + 1 != objs.length ? self.makeLink(objs[i + 1]) : null
+                };
             }
 
             return theMap;
@@ -208,7 +191,7 @@ require(["lib/models", "lib/tools", "knockout", "sammy"], function(models, tools
         self.nextAbstract = function(abstract) {
           var uuid = abstract.uuid;
 
-            if(!uuid in self.neighbours) {
+            if (!uuid in self.neighbours) {
                 return null;
             }
 
@@ -218,56 +201,52 @@ require(["lib/models", "lib/tools", "knockout", "sammy"], function(models, tools
         self.prevAbstract = function(abstract) {
             var uuid = abstract.uuid;
 
-            if(!uuid in self.neighbours) {
+            if (!uuid in self.neighbours) {
                 return null;
             }
 
             return self.neighbours[uuid].prev;
         };
 
-        //Data IO
+        // Data IO
         self.ioFailHandler = function(jqxhr, textStatus, error) {
-            var err = textStatus + ", " + error;
-            console.log( "Request Failed: " + err );
             self.setError("danger", "Error while fetching data from server: <br\\>" + error);
         };
 
         self.ensureDataAndThen = function(doAfter) {
-            console.log("ensureDataAndThen::");
             self.isLoading(true);
             if (self.abstractsData !== null) {
                 doAfter();
                 self.isLoading(false);
                 return;
             }
-            if (localStorage.getItem(confId) !== null){
+            if (localStorage.getItem(confId) !== null) {
                 onConferenceData(JSON.parse(localStorage.getItem(confId)));
-                //return
+                // return;
             }
 
-            //now load the data from the server
-            var confURL ="/api/conferences/" + confId;
+            var confURL = "/api/conferences/" + confId;
             $.getJSON(confURL, onConferenceData).fail(self.ioFailHandler);
 
-            //conference data
+            // Conference data
             function onConferenceData(confObj) {
                 localStorage.setItem(confId, JSON.stringify(confObj));
-                var x = localStorage.getItem(confId)
+                var x = localStorage.getItem(confId);
                 var conf = models.Conference.fromObject(confObj);
                 self.conference(conf);
                 self.buildGroups();
-                //now load the abstract data
-                var abs = localStorage.getItem(confId+'_abs')
+                // Load abstract data
+                var abs = localStorage.getItem(confId + "_abs");
                 if (abs !==  null) {
-                    onAbstractData(JSON.parse(abs))
-                    return
+                    onAbstractData(JSON.parse(abs));
+                    return;
                 }
                 $.getJSON(conf.abstracts, onAbstractData).fail(self.ioFailHandler);
             }
 
-            //abstract data
+            // Abstract data
             function onAbstractData(absArray) {
-                localStorage.setItem(confId+'_abs', JSON.stringify(absArray))
+                localStorage.setItem(confId + "_abs", JSON.stringify(absArray));
                 var absList = models.Abstract.fromArray(absArray);
                 self.abstractsData = absList;
                 self.buildMaps();
@@ -281,45 +260,32 @@ require(["lib/models", "lib/tools", "knockout", "sammy"], function(models, tools
 
         // client-side routes
         Sammy(function() {
-
-            this.get('#/uuid/:uuid', function() {
-                var uuid = this.params['uuid'];
-                console.log("Sammy::get::uuid [" + uuid + "]");
+            this.get("#/uuid/:uuid", function() {
+                var uuid = this.params["uuid"];
                 self.ensureDataAndThen(function () {
                     self.showAbstractByUUID(uuid);
                 });
             });
 
-            this.get('#/groups/:group', function() {
-                var group = this.params['group'];
-                console.log("Sammy::get::group [" + group + "]");
+            this.get("#/groups/:group", function() {
+                var group = this.params["group"];
                 self.ensureDataAndThen(function () {
                     self.showAbstractsByGroup(group);
                 });
             });
 
-
-            this.get('#/', function() {
-                console.log('Sammy::get::');
+            this.get("#/", function() {
                 self.ensureDataAndThen(function () {
                     self.showAbstractList(self.abstractsData);
                 });
             });
-
-        }).run('#/');
-
+        }).run("#/");
     }
 
-
     $(document).ready(function() {
-
         var data = tools.hiddenData();
-
-        console.log(data.conferenceUuid);
-
         window.abstractList = AbstractListViewModel(data.conferenceUuid);
         window.abstractList.init();
     });
-
 });
 });

--- a/app/assets/javascripts/userdash.js
+++ b/app/assets/javascripts/userdash.js
@@ -26,7 +26,7 @@ require(["lib/models", "lib/tools", "knockout", "sammy"], function (models, tool
         };
 
         self.setInfo = function (level, text) {
-            self.error({message: text, level: 'callout-' + level});
+            self.error({message: text, level: "callout-" + level});
             self.isLoading(false);
         };
 
@@ -50,8 +50,8 @@ require(["lib/models", "lib/tools", "knockout", "sammy"], function (models, tool
 
             // Conference data
             function onConferenceData(confObj) {
-                if((typeof confObj === 'string' || confObj instanceof String) && confObj.length == 0){
-                    self.setInfo("info","You have no own abstracts created yet.");
+                if ((typeof confObj === "string" || confObj instanceof String) && confObj.length == 0) {
+                    self.setInfo("info", "You have no own abstracts created yet.");
                     return;
                 }
                 var confs = models.Conference.fromArray(confObj);

--- a/app/assets/javascripts/userdash.js
+++ b/app/assets/javascripts/userdash.js
@@ -2,17 +2,14 @@ require(["main"], function () {
 require(["lib/models", "lib/tools", "knockout", "sammy"], function (models, tools, ko, Sammy) {
     "use strict";
 
-
     /**
-     * AbstractList view model.
+     * User dash view model.
      *
      *
-     * @param confId
-     * @returns {AbstractListViewModel}
+     * @returns {UserDashViewModel}
      * @constructor
      */
     function UserDashViewModel() {
-
         if (!(this instanceof UserDashViewModel)) {
             return new UserDashViewModel();
         }
@@ -23,9 +20,8 @@ require(["lib/models", "lib/tools", "knockout", "sammy"], function (models, tool
         self.isLoading = ko.observable(true);
         self.error = ko.observable(false);
 
-
         self.setError = function (level, text) {
-            self.error({message: text, level: 'alert-' + level});
+            self.error({message: text, level: "alert-" + level});
             self.isLoading(false);
         };
 
@@ -33,7 +29,6 @@ require(["lib/models", "lib/tools", "knockout", "sammy"], function (models, tool
             self.error({message: text, level: 'callout-' + level});
             self.isLoading(false);
         };
-
 
         self.init = function () {
             ko.applyBindings(window.dashboard);
@@ -43,24 +38,18 @@ require(["lib/models", "lib/tools", "knockout", "sammy"], function (models, tool
             return "/myabstracts/" + abstract.uuid + "/edit";
         };
 
-
-        //Data IO
+        // Data IO
         self.ioFailHandler = function (jqxhr, textStatus, error) {
             var err = textStatus + ", " + error + ", " + jqxhr.responseText;
-            console.log("Request Failed: " + err);
             self.setError("danger", "Error while loading data [" + err + "]!");
         };
 
         self.ensureDataAndThen = function (doAfter) {
-            console.log("ensureDataAndThen::");
-
-            //now load the data from the server
             var confURL = "/api/user/self/conferences";
             $.getJSON(confURL, onConferenceData).fail(self.ioFailHandler);
 
-            //conference data
+            // Conference data
             function onConferenceData(confObj) {
-                console.log("+ onConferenceData");
                 if((typeof confObj === 'string' || confObj instanceof String) && confObj.length == 0){
                     self.setInfo("info","You have no own abstracts created yet.");
                     return;
@@ -92,13 +81,12 @@ require(["lib/models", "lib/tools", "knockout", "sammy"], function (models, tool
                     var absList = models.Abstract.fromArray(abstractList);
 
                     absList.forEach(function (abstr) {
-
                         abstr.viewEditCtx = ko.computed(function () {
                             var confIsOpen = currentConf.isOpen;
-                            var canEdit = abstr.state == "InRevision" ||
-                                (confIsOpen && (abstr.state == "InPreparation" ||
-                                abstr.state == "Submitted" ||
-                                abstr.state == "Withdrawn"));
+                            var canEdit = abstr.state === "InRevision" ||
+                                (confIsOpen && (abstr.state === "InPreparation" ||
+                                abstr.state === "Submitted" ||
+                                abstr.state === "Withdrawn"));
 
                             return {
                                 link: canEdit ? "/myabstracts/" + abstr.uuid + "/edit" : "/abstracts/" + abstr.uuid,
@@ -109,33 +97,25 @@ require(["lib/models", "lib/tools", "knockout", "sammy"], function (models, tool
                     });
 
                     currentConf.abstracts(absList);
-                }
+                };
             }
         };
 
-
-        // client-side routes
+        // Client-side routes
         Sammy(function () {
-
-            this.get('#/', function () {
-                console.log('Sammy::get::');
+            this.get("#/", function () {
                 self.ensureDataAndThen(function () {
                     self.isLoading(false);
                 });
             });
-
-        }).run('#/');
-
+        }).run("#/");
     }
 
     $(document).ready(function () {
-
         var data = tools.hiddenData();
-
 
         window.dashboard = UserDashViewModel();
         window.dashboard.init();
     });
-
 });
 });

--- a/app/assets/javascripts/userdash.js
+++ b/app/assets/javascripts/userdash.js
@@ -69,8 +69,10 @@ require(["lib/models", "lib/tools", "knockout", "sammy"], function (models, tool
                 if (confs !== null) {
                     confs.forEach(function (current) {
                         current.abstracts = ko.observableArray(null);
+                        current.localConferenceLink = ko.computed(function() {
+                            return "/conference/" + current.short + "/abstracts";
+                        });
                     });
-
                 }
 
                 self.conferences(confs);

--- a/app/assets/stylesheets/layout.less
+++ b/app/assets/stylesheets/layout.less
@@ -26,6 +26,11 @@ body {
   margin-bottom: 20px;
 }
 
+.navbar-nav > li > a {
+    padding-top: 10px;
+    padding-bottom: 10px;
+}
+
 .conference-logo {
   max-height: 128px;
   display: block;

--- a/app/assets/stylesheets/layout.less
+++ b/app/assets/stylesheets/layout.less
@@ -26,11 +26,6 @@ body {
   margin-bottom: 20px;
 }
 
-.navbar-nav > li > a {
-    padding-top: 10px;
-    padding-bottom: 10px;
-}
-
 .conference-logo {
   max-height: 128px;
   display: block;

--- a/app/conf/Global.scala
+++ b/app/conf/Global.scala
@@ -8,6 +8,7 @@ import com.mohiva.play.silhouette.core.exceptions.AccessDeniedException
 import com.mohiva.play.silhouette.core.{Environment, SecuredSettings}
 import models.Login
 import play.api._
+import play.api.i18n.Lang
 import play.api.libs.json.{JsObject, JsError, JsResultException, Json}
 import play.api.mvc.Results._
 import play.api.mvc._
@@ -17,6 +18,10 @@ object Global extends GlobalSettings with SecuredSettings {
 
   import play.api.Play.current
   implicit lazy val globalEnv = new GlobalEnvironment()
+
+  override def onNotAuthenticated(request: RequestHeader, lang: Lang) = {
+    Option(Future.successful(NotFound(views.html.error.NotAuthorized())))
+  }
 
   override def onHandlerNotFound(request: RequestHeader) = {
     Future.successful(NotFound(views.html.error.NotFound()))

--- a/app/conf/Global.scala
+++ b/app/conf/Global.scala
@@ -20,7 +20,11 @@ object Global extends GlobalSettings with SecuredSettings {
   implicit lazy val globalEnv = new GlobalEnvironment()
 
   override def onNotAuthenticated(request: RequestHeader, lang: Lang) = {
-    Option(Future.successful(NotFound(views.html.error.NotAuthorized())))
+    Option(Future.successful(Unauthorized(views.html.error.NotAuthenticated())))
+  }
+
+  override def onNotAuthorized(request: RequestHeader, lang: Lang) = {
+    Option(Future.successful(Forbidden(views.html.error.NotAuthorized())))
   }
 
   override def onHandlerNotFound(request: RequestHeader) = {

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -113,6 +113,10 @@ class Application(implicit val env: Environment[Login, CachedCookieAuthenticator
     Ok(views.html.impressum(request.identity.map{ _.account }))
   }
 
+  def datenschutz = UserAwareAction { implicit request =>
+    Ok(views.html.datenschutz(request.identity.map{ _.account }))
+  }
+
   def about = UserAwareAction { implicit request =>
     Ok(views.html.about(request.identity.map{ _.account }))
   }

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -33,7 +33,6 @@ class Application(implicit val env: Environment[Login, CachedCookieAuthenticator
     Ok("Hello %s".format(userName))
   }
 
-
   def submission(id: String) = UserAwareAction { implicit request => // TODO should be a secure action
     val user: Account = request.identity match {
       case Some(id: Login) => id.account
@@ -45,9 +44,13 @@ class Application(implicit val env: Environment[Login, CachedCookieAuthenticator
   }
 
   def edit(id: String) = SecuredAction { implicit request =>
-    val abstr = abstractService.getOwn(id, request.identity.account)
+    try {
+      val abstr = abstractService.getOwn(id, request.identity.account)
 
-    Ok(views.html.submission(request.identity.account, abstr.conference, Option(abstr)))
+      Ok(views.html.submission(request.identity.account, abstr.conference, Option(abstr)))
+    } catch {
+      case ia: IllegalAccessException => Forbidden(views.html.error.NotAuthorized())
+    }
   }
 
   def abstractsPublic(confId: String) = UserAwareAction { implicit request =>

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -192,12 +192,13 @@ class Application(implicit val env: Environment[Login, CachedCookieAuthenticator
 
     Ok(
       s"""CACHE MANIFEST
-         |# v1.0.1
+         |# v1.0.2
          |# Views
          |/conferences
          |/contact
          |/about
          |/impressum
+         |/datenschutz
          |# Assets
          |/assets/manifest.json
          |/assets/lib/momentjs/moment.js
@@ -247,6 +248,7 @@ class Application(implicit val env: Environment[Login, CachedCookieAuthenticator
          |# View Models
          |/assets/javascripts/abstract-list.js
          |/assets/javascripts/abstract-viewer.js
+         |/assets/javascripts/abstract-favourite.js
          |/assets/javascripts/browser.js
          |/assets/javascripts/conference-schedule.js
          |/assets/javascripts/config.js

--- a/app/controllers/api/Abstracts.scala
+++ b/app/controllers/api/Abstracts.scala
@@ -263,7 +263,7 @@ extends Silhouette[Login, CachedCookieAuthenticator] {
     Ok(abstr.favUsers.contains(request.identity.account).toString)
   }
   /**
-    * Add the loggend in user to the favourite users list of an abstract.
+    * Add the logged in user to the favourite users list of an abstract.
     *
     * @return The id of the updated Abstract as JSON
     */

--- a/app/controllers/api/Abstracts.scala
+++ b/app/controllers/api/Abstracts.scala
@@ -263,15 +263,14 @@ extends Silhouette[Login, CachedCookieAuthenticator] {
     Ok(abstr.favUsers.contains(request.identity.account).toString)
   }
   /**
-    * Add favourite users of the abstract.
+    * Add the loggend in user to the favourite users list of an abstract.
     *
-    * @return a list of updated permissions (accounts) as JSON
+    * @return The id of the updated Abstract as JSON
     */
-  def addFavUser(id: String) = SecuredAction { implicit request =>
-    Logger.debug(s"Liking abstract with uuid: [$id]")
+  def addFavUser(id: String) = SecuredAction(parse.json) { implicit request =>
     val abstr = abstractService.get(id)
     abstractService.addFavUser(abstr, request.identity.account)
-    Ok(views.html.dashboard.favouriteabstracts(request.identity.account))
+    Ok(Json.toJson(id))
   }
   /**
     * Remove favourite users of the abstract.

--- a/app/controllers/api/Abstracts.scala
+++ b/app/controllers/api/Abstracts.scala
@@ -273,15 +273,14 @@ extends Silhouette[Login, CachedCookieAuthenticator] {
     Ok(Json.toJson(id))
   }
   /**
-    * Remove favourite users of the abstract.
+    * Remove the logged in user from the favourite users list of an abstract.
     *
-    * @return a list of updated permissions (accounts) as JSON
+    * @return The id of the updated Abstract as JSON
     */
-  def removeFavUser(id: String) = SecuredAction { implicit request =>
-    Logger.debug(s"Disliking abstract with uuid: [$id]")
+  def removeFavUser(id: String) = SecuredAction(parse.json) { implicit request =>
     val abstr = abstractService.get(id)
     abstractService.removeFavUser(abstr, request.identity.account)
-    Ok(views.html.dashboard.favouriteabstracts(request.identity.account))
+    Ok(Json.toJson(id))
   }
 
   def listState(id: String) = SecuredAction { implicit request =>

--- a/app/views/abstractlist.scala.html
+++ b/app/views/abstractlist.scala.html
@@ -86,7 +86,7 @@
 
             @if(account.isDefined) {
                 <li data-bind="visible: !$root.isFavouriteAbstract()">
-                    <a class="favour" data-bind="attr:{href : $root.favourAbstract($data)}">&#9733</a>
+                    <a class="favour" data-bind="click: $root.favourAbstract">&#9733</a>
                 </li>
                 <li data-bind="visible: $root.isFavouriteAbstract">
                     <a class="disfavour" data-bind="attr:{href : $root.disfavourAbstract($data)}">&#9733</a>

--- a/app/views/abstractlist.scala.html
+++ b/app/views/abstractlist.scala.html
@@ -89,7 +89,7 @@
                     <a class="favour" data-bind="click: $root.favourAbstract">&#9733</a>
                 </li>
                 <li data-bind="visible: $root.isFavouriteAbstract">
-                    <a class="disfavour" data-bind="attr:{href : $root.disfavourAbstract($data)}">&#9733</a>
+                    <a class="disfavour" data-bind="click: $root.disfavourAbstract">&#9733</a>
                 </li>
             }
 

--- a/app/views/abstractlist.scala.html
+++ b/app/views/abstractlist.scala.html
@@ -31,6 +31,16 @@
         <!-- /ko -->
     </div>
 
+    <!-- Success message box; for unknown reason the css level is not properly updated; keep until resolved -->
+    <div data-bind="visible: messageSuccess">
+        <!-- ko with: messageSuccess -->
+        <div class="alert alert-info fade in alert-dismissable">
+            <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
+            <strong data-bind="html: message"></strong>
+        </div>
+        <!-- /ko -->
+    </div>
+
     <div class="page-header">
         <h1><a href="@conference.link">@conference.name</a></h1>
     </div>

--- a/app/views/abstractlist.scala.html
+++ b/app/views/abstractlist.scala.html
@@ -7,8 +7,8 @@
         <div id="logged-in">@if(account.isDefined) {"true"} else {"false"}</div>
     </div>
 
-    <script data-main="@routes.Assets.at("javascripts/abstract-list.js")"
-            src="@routes.Assets.at("javascripts/require.js")"></script>
+    <script data-main='@routes.Assets.at("javascripts/abstract-list.js")'
+            src='@routes.Assets.at("javascripts/require.js")'></script>
 
     <!-- Loading box -->
     <div data-bind="if: isLoading">
@@ -42,7 +42,7 @@
     </div>
 
     <div class="page-header">
-        <h1><a href="@conference.link">@conference.name</a></h1>
+        <h1><a data-bind="attr: {href: $root.localConferenceLink}">@conference.name</a></h1>
     </div>
 
     <div>
@@ -100,6 +100,5 @@
     } {
         <!-- footer -->
     }
-
     </div> <!-- KO !flickerbox -->
 }

--- a/app/views/bootstrap/password.scala.html
+++ b/app/views/bootstrap/password.scala.html
@@ -10,6 +10,6 @@
             placeholder="@label" />
         <span class="ion-@icon form-control-feedback"></span>
         <span class="help-block">@help</span>
-        <span class="help-block">@{field.error.map { error => Messages(error.message) }}</span>
+        <span class="help-block">@field.error.map(error => Messages(error.message, error.args: _*)).getOrElse("")</span>
     </div>
 </div>

--- a/app/views/conferencelist.scala.html
+++ b/app/views/conferencelist.scala.html
@@ -9,7 +9,7 @@
         var ref = window.sessionStorage.getItem("gca_ref")
         if (ref !== undefined && ref !== null) {
             window.sessionStorage.removeItem("gca_ref");
-            window.location = ref;
+            window.location.replace(ref);
         }
     </script>
 

--- a/app/views/conferencelist.scala.html
+++ b/app/views/conferencelist.scala.html
@@ -4,6 +4,15 @@
 
 @template(account, None, "") {
 
+    <!-- if required redirect after login -->
+    <script>
+        var ref = window.sessionStorage.getItem("gca_ref")
+        if (ref !== undefined && ref !== null) {
+            window.sessionStorage.removeItem("gca_ref");
+            window.location = ref;
+        }
+    </script>
+
     @flash(request)
 
     @if(list_active.nonEmpty) {

--- a/app/views/dashboard/favouriteabstracts.scala.html
+++ b/app/views/dashboard/favouriteabstracts.scala.html
@@ -40,7 +40,7 @@
         <div data-bind="foreach: conferences">
             <div class="panel panel-default">
                 <div class="panel-heading" >
-                    <a data-bind="attr: { href: link }">
+                    <a data-bind="attr: { href: localConferenceLink() }">
                         <h4 class="panel-title" data-bind="text: name"></h4>
                     </a>
                 </div>

--- a/app/views/dashboard/favouriteabstracts.scala.html
+++ b/app/views/dashboard/favouriteabstracts.scala.html
@@ -1,6 +1,6 @@
 @(account: Account)
 
-@template(Some(account), None, "Favourite Abstracts") {
+@template(Some(account), None, "My Favourites") {
 
     <div class="hidden-data">
         <div id="conference-uuid">@account.uuid</div>

--- a/app/views/dashboard/favouriteabstracts.scala.html
+++ b/app/views/dashboard/favouriteabstracts.scala.html
@@ -6,11 +6,10 @@
         <div id="conference-uuid">@account.uuid</div>
     </div>
 
-    <script data-main="@routes.Assets.at("javascripts/abstracts-favourite.js")"
-    src="@routes.Assets.at("javascripts/require.js")"></script>
+    <script data-main='@routes.Assets.at("javascripts/abstracts-favourite.js")'
+            src='@routes.Assets.at("javascripts/require.js")'></script>
 
-
-        <!-- Loading box -->
+    <!-- Loading box -->
     <div data-bind="if: isLoading">
         <div class="alert alert-info fade in out">
             <h4>Loading data</h4>
@@ -18,26 +17,25 @@
         </div>
     </div>
 
-        <!-- If no Favourites -->
+    <!-- If no Favourites -->
     <div data-bind="if: noFavouriteAbstracts">
         <div class="alert alert-info fade in out">
             <h4>You have no favourite abstracts yet. Click the star button shown for abstracts to add them.</h4>
         </div>
     </div>
 
-        <!-- Knockout !flickerbox  -->
+    <!-- Knockout !flickerbox  -->
     <div style="display: none" data-bind="visible: true">
 
-            <!-- Error message box -->
+        <!-- Error message box -->
         <div data-bind="visible: error">
-                <!-- ko with: error -->
+            <!-- ko with: error -->
             <div class="alert alert-warning fade in alert-dismissable" data-bind="css: level">
                 <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
                 <strong data-bind="html: message"></strong>
             </div>
-                <!-- /ko -->
+            <!-- /ko -->
         </div>
-
 
         <div data-bind="foreach: conferences">
             <div class="panel panel-default">
@@ -58,7 +56,5 @@
                 </ul>
             </div>
         </div>
-
     </div>
-
 }

--- a/app/views/dashboard/user.scala.html
+++ b/app/views/dashboard/user.scala.html
@@ -33,7 +33,7 @@
         <div data-bind="foreach: conferences">
             <div class="panel panel-default">
                 <div class="panel-heading" >
-                    <a data-bind="attr: { href: link }">
+                    <a data-bind="attr: { href: localConferenceLink() }">
                         <h4 class="panel-title" data-bind="text: name"></h4>
                     </a>
                 </div>

--- a/app/views/dashboard/user.scala.html
+++ b/app/views/dashboard/user.scala.html
@@ -6,9 +6,8 @@
         <div id="conference-uuid">@account.uuid</div>
     </div>
 
-    <script data-main="@routes.Assets.at("javascripts/userdash.js")"
-                  src="@routes.Assets.at("javascripts/require.js")"></script>
-
+    <script data-main='@routes.Assets.at("javascripts/userdash.js")'
+                  src='@routes.Assets.at("javascripts/require.js")'></script>
 
     <!-- Loading box -->
     <div data-bind="if: isLoading">
@@ -21,24 +20,23 @@
     <!-- Knockout !flickerbox  -->
     <div style="display: none" data-bind="visible: true">
 
-    <!-- Error message box -->
-    <div data-bind="visible: error">
-        <!-- ko with: error -->
-        <div class="alert alert-warning fade in alert-dismissable" data-bind="css: level">
-            <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
-            <strong data-bind="html: message"></strong>
-        </div>
-        <!-- /ko -->
-    </div>
-
-
-    <div data-bind="foreach: conferences">
-        <div class="panel panel-default">
-            <div class="panel-heading" >
-                <a data-bind="attr: { href: link }">
-                    <h4 class="panel-title" data-bind="text: name"></h4>
-                </a>
+        <!-- Error message box -->
+        <div data-bind="visible: error">
+            <!-- ko with: error -->
+            <div class="alert alert-warning fade in alert-dismissable" data-bind="css: level">
+                <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
+                <strong data-bind="html: message"></strong>
             </div>
+            <!-- /ko -->
+        </div>
+
+        <div data-bind="foreach: conferences">
+            <div class="panel panel-default">
+                <div class="panel-heading" >
+                    <a data-bind="attr: { href: link }">
+                        <h4 class="panel-title" data-bind="text: name"></h4>
+                    </a>
+                </div>
                 <div class="panel-body">
                     <span data-bind="text: cite"></span>
                 </div>
@@ -50,9 +48,7 @@
                         </li>
                     </a>
                 </ul>
+            </div>
         </div>
     </div>
-
-    </div>
-
 }

--- a/app/views/dashboard/user.scala.html
+++ b/app/views/dashboard/user.scala.html
@@ -1,6 +1,6 @@
 @(account: Account)
 
-@template(Some(account), None, "Abstracts") {
+@template(Some(account), None, "My Abstracts") {
 
     <div class="hidden-data">
         <div id="conference-uuid">@account.uuid</div>

--- a/app/views/datenschutz.scala.html
+++ b/app/views/datenschutz.scala.html
@@ -1,0 +1,145 @@
+@(account: Option[Account])
+
+@template(account, None, "Datenschutz") {
+
+<!-- Datenschutz -->
+<div class="page-header">
+    <h1>Datenschutzerklärung</h1>
+</div>
+<div>
+    <p>Diese Datenschutzerklärung beruht auf den Begrifflichkeiten, die durch den Europäischen Richtlinien-
+        und Verordnungsgeber beim Erlass der
+        <a href="https://dsgvo-gesetz.de" rel="nofollow">Datenschutz-Grundverordnung (DS-GVO)</a> verwendet wurden.</p>
+
+    <p>Verantwortliche Stelle im Sinne der Datenschutzgesetze, insbesondere der EU-Datenschutzgrundverordnung (DSGVO):</p>
+
+    <p>German Neuroinformatics Node (G-Node)<br>
+        Department Biologie II<br>
+        Ludwig-Maximilians-Universität München<br>
+        Großhaderner Str. 2<br>
+        82152 Planegg-Martinsried<br>
+        Deutschland</p>
+
+    <p>Tel.: 089 2180 74810<br>
+        E-Mail: info@@g-node.org</p>
+
+    <p class="lead">Ihre Betroffenenrechte</p>
+
+    <p>Unter den angegebenen Kontaktdaten unseres Datenschutzbeauftragten können Sie jederzeit folgende Rechte ausüben:</p>
+
+    <ul>
+        <li>Auskunft über Ihre bei uns gespeicherten Daten und deren Verarbeitung,</li>
+        <li>Berichtigung unrichtiger personenbezogener Daten,</li>
+        <li>Löschung Ihrer bei uns gespeicherten Daten,</li>
+        <li>Einschränkung der Datenverarbeitung, sofern wir Ihre Daten aufgrund
+            gesetzlicher Pflichten noch nicht löschen dürfen,</li>
+        <li>Widerspruch gegen die Verarbeitung Ihrer Daten bei uns und</li>
+        <li>Datenübertragbarkeit, sofern Sie in die Datenverarbeitung eingewilligt haben
+            oder einen Vertrag mit uns abgeschlossen haben.</li>
+    </ul>
+
+    <p>Eine von Ihnen erteilte Einwilligung können Sie jederzeit mit Wirkung für die Zukunft  widerrufen.</p>
+
+    <p>Sie können sich jederzeit mit einer Beschwerde an die für Sie zuständige Aufsichtsbehörde wenden.
+        Ihre zuständige Aufsichtsbehörde richtet sich nach dem Bundesland Ihres Wohnsitzes, Ihrer Arbeit
+        oder der mutmaßlichen Verletzung. Eine Liste der Aufsichtsbehörden (für den nichtöffentlichen Bereich)
+        mit Anschrift finden Sie unter:
+        <a href="https://www.bfdi.bund.de/DE/Infothek/Anschriften_Links/anschriften_links-node.html" rel="nofollow">
+            https://www.bfdi.bund.de/DE/Infothek/Anschriften_Links/anschriften_links-node.html
+        </a>.
+    </p>
+
+    <p class="lead">Zwecke der Datenverarbeitung</p>
+
+    <p>Unsere Dienste richten sich an Wissenschaftler zur Unterstützung ihrer wissenschaftlicher Tätigkeit,
+        insbesondere des wissenschaftlichen Austausches und der Veröffentlichung von Forschungsergebnissen.
+        Wir verarbeiten Ihre personenbezogenen Daten nur zu diesen Zwecken. Eine Übermittlung
+        Ihrer persönlichen Daten an Dritte zu anderen als den genannten Zwecken findet nicht statt.
+        Wir geben Ihre persönlichen Daten nur an Dritte weiter, wenn:</p>
+
+    <ul>
+        <li>Sie Ihre ausdrückliche Einwilligung dazu erteilt haben,</li>
+        <li>die Verarbeitung zur Ausführung der von Ihnen in Anspruch genommenen  Dienste erforderlich ist,</li>
+        <li>die Verarbeitung zur Erfüllung einer rechtlichen Verpflichtung erforderlich ist,</li>
+    </ul>
+
+    <p>die Verarbeitung zur Wahrung berechtigter Interessen erforderlich ist und kein Grund zur Annahme besteht,
+        dass Sie ein überwiegendes schutzwürdiges Interesse an der Nichtweitergabe Ihrer Daten haben.</p>
+
+    <p class="lead">Löschung bzw. Sperrung der Daten</p>
+
+    <p>Wir halten uns an die Grundsätze der Datenvermeidung und Datensparsamkeit. Wir speichern Ihre personenbezogenen
+        Daten daher nur so lange, wie dies zur Erreichung der hier genannten Zwecke erforderlich ist oder wie es die
+        vom Gesetzgeber vorgesehenen vielfältigen Speicherfristen vorsehen. Nach Fortfall des jeweiligen Zweckes bzw.
+        Ablauf dieser Fristen werden die entsprechenden Daten routinemäßig und entsprechend den gesetzlichen
+        Vorschriften gesperrt oder gelöscht.</p>
+
+    <p class="lead">Cookies</p>
+
+    <p>Wie viele andere Webseiten verwenden wir auch so genannte „Cookies“. Cookies sind kleine Textdateien,
+        die von einem Websiteserver auf Ihre Festplatte übertragen werden. Hierdurch erhalten wir automatisch
+        bestimmte Daten wie z. B. IP-Adresse, verwendeter Browser, Betriebssystem und Ihre Verbindung zum Internet.</p>
+
+    <p>Cookies können nicht verwendet werden, um Programme zu starten oder Viren auf einen Computer zu übertragen.
+        Anhand der in Cookies enthaltenen Informationen können wir Ihnen die Navigation erleichtern
+        und die korrekte Anzeige unserer Webseiten ermöglichen.</p>
+
+    <p>In keinem Fall werden die von uns erfassten Daten an Dritte weitergegeben oder ohne Ihre Einwilligung
+        eine Verknüpfung mit personenbezogenen Daten hergestellt.</p>
+
+    <p>Natürlich können Sie unsere Website grundsätzlich auch ohne Cookies betrachten.
+        Internet-Browser sind regelmäßig so eingestellt, dass sie Cookies akzeptieren.
+        Im Allgemeinen können Sie die Verwendung von Cookies jederzeit
+        über die Einstellungen Ihres Browsers deaktivieren. Bitte verwenden Sie die Hilfefunktionen
+        Ihres Internetbrowsers, um zu erfahren, wie Sie diese Einstellungen ändern können. Bitte beachten Sie,
+        dass einzelne Funktionen unserer Website möglicherweise nicht funktionieren,
+        wenn Sie die Verwendung von Cookies deaktiviert haben.</p>
+
+    <p class="lead">Nutzerregistrierung</p>
+
+    <p>Bei der Registrierung für die Nutzung unserer personalisierten Leistungen werden einige personenbezogene Daten
+        wie Name und E-Mail-Adresse erhoben. Sind Sie bei uns registriert,
+        können Sie auf Inhalte und Leistungen zugreifen, die wir nur registrierten Nutzern anbieten.
+        Angemeldete Nutzer haben jederzeit die Möglichkeit, bei Bedarf die bei Registrierung angegebenen Daten
+        zu ändern oder zu löschen. Selbstverständlich erteilen wir Ihnen darüber hinaus jederzeit Auskunft
+        über die von uns über Sie gespeicherten personenbezogenen Daten. Gerne berichtigen bzw.
+        löschen wir diese auch auf Ihren Wunsch, soweit keine gesetzlichen Aufbewahrungspflichten entgegenstehen.
+        Zur Kontaktaufnahme in diesem Zusammenhang nutzen Sie bitte die in dieser Datenschutzerklärung angegebenen
+        Kontaktdaten.</p>
+
+    <p class="lead">SSL-Verschlüsselung</p>
+
+    <p>Um die Sicherheit Ihrer Daten bei der Übertragung zu schützen, verwenden wir dem aktuellen
+        Stand der Technik entsprechende Verschlüsselungsverfahren (z. B. SSL) über HTTPS.</p>
+
+    <p class="lead">Änderungsverfolgung</p>
+
+    <p>Wenn Nutzer Inhalte einreichen oder ändern, werden neben diesen Änderungen auch der Zeitpunkt ihrer Erstellung
+        und der Nutzername gespeichert. Dies dient der Verifizierbarkeit der zum Zweck der Publikation eingereichten
+        Informationen. Es dient auch unserer Sicherheit, da wir für widerrechtliche Inhalte auf unserer Webseite
+        belangt werden können, auch wenn diese durch Benutzer erstellt wurden.</p>
+
+    <p class="lead">Verwendung von Scriptbibliotheken (Google Webfonts)</p>
+
+    <p>Um unsere Inhalte browserübergreifend korrekt und grafisch ansprechend darzustellen,
+        verwenden wir auf dieser Website Scriptbibliotheken und Schriftbibliotheken wie
+        z. B. Google Webfonts (<a href="http://www.google.com/webfonts/" rel="nofollow">https://www.google.com/webfonts/</a>).
+        Google Webfonts werden zur Vermeidung mehrfachen Ladens in den Cache Ihres Browsers übertragen.
+        Falls der Browser die Google Webfonts nicht unterstützt oder den Zugriff unterbindet,
+        werden Inhalte in einer Standardschrift angezeigt.</p>
+
+    <p>Der Aufruf von Scriptbibliotheken oder Schriftbibliotheken löst automatisch eine Verbindung zum Betreiber
+        der Bibliothek aus. Dabei ist es theoretisch möglich – aktuell allerdings auch unklar ob
+        und ggf. zu welchen Zwecken – dass Betreiber entsprechender Bibliotheken Daten erheben.</p>
+
+    <p>Die Datenschutzrichtlinie des Bibliothekbetreibers Google finden Sie hier:
+        <a href="https://www.google.com/policies/privacy/" rel="nofollow">https://www.google.com/policies/privacy/</a></p>
+
+    <p class="lead"><strong>Änderung unserer Datenschutzbestimmungen</strong></p>
+
+    <p>Wir behalten uns vor, diese Datenschutzerklärung anzupassen, damit sie stets
+        den aktuellen rechtlichen Anforderungen entspricht oder um Änderungen unserer Leistungen
+        in der Datenschutzerklärung umzusetzen, z.B. bei der Einführung neuer Services.
+        Für Ihren erneuten Besuch gilt dann die neue Datenschutzerklärung.</p>
+</div>
+}

--- a/app/views/error/NotAuthenticated.scala.html
+++ b/app/views/error/NotAuthenticated.scala.html
@@ -1,0 +1,14 @@
+@()(implicit lang: Lang)
+@template(None, None, "") {
+
+<script>
+    var loc = location.origin + "/login";
+    window.location.replace(loc);
+</script>
+
+<div class="callout-danger">
+    <h2>Provide authentication - 401 </h2>
+    <p>You are not authenticated to view this page.
+        If you are not automatically redirected to the login page, please login manually.</p>
+</div>
+}

--- a/app/views/login.scala.html
+++ b/app/views/login.scala.html
@@ -14,6 +14,13 @@
       @text(form("identifier"), "Email", icon = "at")
       @password(form("password"), "Password", icon = "key")
 
+      <!-- Provide redirection after login -->
+      <script>
+        if (!document.referrer.includes("/login")) {
+          window.sessionStorage.setItem("gca_ref", document.referrer);
+        }
+      </script>
+
       <div class="form-group">
         <a href="@routes.Accounts.forgotPasswordPage()">Forgot password?</a>
         or

--- a/app/views/login.scala.html
+++ b/app/views/login.scala.html
@@ -14,10 +14,11 @@
       @text(form("identifier"), "Email", icon = "at")
       @password(form("password"), "Password", icon = "key")
 
-      <!-- Provide redirection after login -->
+      <!-- Provide redirection after login from landing page /conferences -->
       <script>
-        if (!document.referrer.includes("/login")) {
-          window.sessionStorage.setItem("gca_ref", document.referrer);
+        var ref = document.referrer;
+        if (ref !== null && ref !== undefined && ref.includes(window.location.hostname) && !ref.includes("/login")) {
+          window.sessionStorage.setItem("gca_ref", ref);
         }
       </script>
 

--- a/app/views/mob_template.scala.html
+++ b/app/views/mob_template.scala.html
@@ -12,11 +12,12 @@
           \____|     |_| \_|\___/ \__,_|\___|
 
           Brought to you by the German Neuroinformatics Node (G-Node) @@gnode
-          Copyright (c) 2013,2014,2018 G-Node
+          Copyright (c) 2013,2014,2019 G-Node
           License: BSD-4 clause and Apache 2.0 (see http://www.apache.org/licenses/LICENSE-2.0.html)
           Authors: Christian Garbers <christian@@stuebeweg50.de>
                    Christian Kellner <kellner@@bio.lmu.de>
                    Andrey Sobolev <sobolev.andrey@@gmail.com>
+                   Michael Sonntag <sonntag@@bio.lmu.de>
                    Adrian Stoewer <adrian.stoewer@@rz.ifi.lmu.de>
 
     -->
@@ -181,12 +182,13 @@
             <div class="row">
                 <div class="pull-left">
                     <ul class="list-inline">
+                        <li><a href="@routes.Application.about">About</a></li>
                         <li><a href="@routes.Application.contact">Contact</a></li>
                         <li><a href="@routes.Application.impressum">Imprint</a></li>
-                        <li><a href="@routes.Application.about">About</a></li>
+                        <li><a href="@routes.Application.datenschutz">Datenschutz</a></li>
                     </ul>
                 </div>
-                <div class="pull-right"><p>The G-Node Conference Site &mdash; © <a href="http://www.g-node.org">G-Node</a> 2018 </p></div>
+                <div class="pull-right"><p>The G-Node Conference Site &mdash; © <a href="http://www.g-node.org">G-Node</a> 2019 </p></div>
             </div>
         </div>
     </div>

--- a/app/views/submission.scala.html
+++ b/app/views/submission.scala.html
@@ -569,6 +569,8 @@
     </script>
     <script id="body-figure-editor" type="text/html">
         <div data-bind="visible: !(abstract().figures().length>=@conference.abstractMaxFigures)">
+            <div>Figures of format "jpg", "gif", "png" are supported; the size limit is 5MB.</div>
+            <br>
             <div class="form-group">
                 <input type="text" name="figure-caption" id="figure-caption" class="form-control input-sm"
                     placeholder='Figure Caption (max. @Model.getLimit[Figure]("caption") characters)'

--- a/app/views/template.scala.html
+++ b/app/views/template.scala.html
@@ -180,7 +180,6 @@
 
                 @if(!conference.isEmpty){
                     <div class="row">
-                        <div class="navbar-header col-md-1"></div>
                         <div class="navbar-collapse collapse">
                             <ul class="nav navbar-nav">
                                 @conference.map { conf =>
@@ -216,6 +215,12 @@
                                     && (Json.parse(conf.geo) \\ "floorplans").size > 0) {
                                         <li class=@if(active.toLowerCase == "floorplans") {"active"} else {""}>
                                             <a href="@routes.Application.floorplans(conf.short)">Floorplans</a>
+                                        </li>
+                                    }
+
+                                    @if(conf.link != null && conf.link.length > 0) {
+                                        <li>
+                                            <a href="@conf.link">Conference home</a>
                                         </li>
                                     }
 

--- a/app/views/template.scala.html
+++ b/app/views/template.scala.html
@@ -226,9 +226,10 @@
             <div class="row">
                 <div class="pull-left">
                     <ul class="list-inline">
+                        <li><a href="@routes.Application.about">About</a></li>
                         <li><a href="@routes.Application.contact">Contact</a></li>
                         <li><a href="@routes.Application.impressum">Imprint</a></li>
-                        <li><a href="@routes.Application.about">About</a></li>
+                        <li><a href="@routes.Application.datenschutz">Datenschutz</a></li>
                     </ul>
                 </div>
                 <div class="pull-right"><p>The G-Node Conference Site &mdash; © <a href="http://www.g-node.org">G-Node</a> 2019 </p></div>

--- a/app/views/template.scala.html
+++ b/app/views/template.scala.html
@@ -77,146 +77,160 @@
 <body>
     <div class="container">
     <!-- navigation -->
-    <div class="navbar navbar-default">
 
-            <div class="navbar-header">
-                <!-- toggle nav button for small screens -->
-                <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
-                    <span class="sr-only">Toggle navigation</span>
-                    <span class="icon-bar"></span>
-                    <span class="icon-bar"></span>
-                    <span class="icon-bar"></span>
-                </button>
-                <!-- left hand side brand / icon -->
-                <a class="navbar-brand" href="/">
-                    <span class="glyphicon glyphicon-home"></span>
-                    @if(conference.isEmpty) {
-                        Conference abstracts and submission
-                    }
-                </a>
-            </div>
-            <div class="navbar-collapse collapse">
-                <ul class="nav navbar-nav">
-                    @conference.map { conf =>
-                        <li class=@if(active.toLowerCase == "conference") {"active"} else {""}>
-                            <a href="@routes.Application.conference(conf.short)"> @conference.get.short</a>
-                        </li>
-
-                        @if(conf.schedule != null && conf.schedule.length > 0
-                                && Json.parse(conf.schedule).asOpt[List[JsValue]] != None
-                                && Json.parse(conf.schedule).as[List[JsValue]].length > 0) {
-                            <li class=@if(active.toLowerCase == "conferenceschedule") {"active"} else {""}>
-                                <a href="@routes.Application.schedule(conf.short)">Schedule</a>
-                            </li>
-                        }
-
-                        @if(conf.isPublished) {
-                            <li class=@if(active.toLowerCase == "abstracts") {"active"} else {""}>
-                                <a href="@routes.Application.abstractsPublic(conf.short)">Abstracts</a>
-                            </li>
-                        }
-
-                    @if(conf.geo != null && conf.geo.length > 0
-                            && Json.parse(conf.geo).asOpt[List[JsValue]] != None
-                            && Json.parse(conf.geo).as[List[JsValue]].length > 0){
-                        <li class=@if(active.toLowerCase == "locations") {"active"} else{""} >
-                            <a href="@routes.Application.locations(conf.short)">Locations</a>
-                        </li>
-                    }
-
-                    @if(conf.geo != null && conf.geo.length > 0
-                            && Json.parse(conf.geo).asOpt[List[JsValue]] != None
-                            && Json.parse(conf.geo).as[List[JsValue]].length > 0
-                            && (Json.parse(conf.geo) \\ "floorplans").size > 0){
-                        <li class=@if(active.toLowerCase == "floorplans") {"active"} else {""}>
-                            <a href="@routes.Application.floorplans(conf.short)">Floorplans</a>
-                        </li>
-                    }
-
-                    @if(conference.get.isOpen && account.isDefined) {
-                            <li class=@if(active.toLowerCase == "submission") {"active"} else {""}>
-                                <a href="@routes.Application.submission(conf.short)">Submission</a>
-                            </li>
-                        }
-                    }
-
-                    @if(account.isDefined) {
-                        @account.map { acc =>
-                            <li class=@if(active.toLowerCase == "my abstracts") {"active"} else {""}>
-                                <a href="@routes.Application.abstractsPrivate()">My Abstracts</a>
-                            </li>
-                        }
-
-                        @account.map { acc =>
-                            <li class=@if(active.toLowerCase == "my favourites") {"active"} else {""}>
-                                <a href="@routes.Application.abstractsFavourite()">My Favourites</a>
-                            </li>
-                        }
-                    }
-
-                    @if(conference.isEmpty && active) {
-                        @if(!active.toLowerCase == "my abstracts" && !active.toLowerCase == "my favourites") {
-                            <li class="active"><a>@active</a></li>
-                        }
-                    }
-                </ul>
-
-                <ul class="nav navbar-nav navbar-right">
-                    @account.map { acc =>
-                        <li class="dropdown">
-                            <a href="#" id="usermenu" role="button" class="dropdown-toggle" data-toggle="dropdown">
-                                @acc.firstName @acc.lastName
-                                <b class="caret"></b>
-                            </a>
-
-                            <ul class="dropdown-menu" role="menu" aria-labelledby="usermenu">
-                                <li role="presentation">
-                                    <a role="menuitem" tabindex="-1" href="@routes.Application.abstractsPrivate()">My Abstracts</a>
+    <div class="container">
+        <div class="navbar navbar-default">
+            <div class="container-fluid">
+                <div class="row">
+                    <div class="navbar-header">
+                        <!-- toggle nav button for small screens -->
+                        <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+                            <span class="sr-only">Toggle navigation</span>
+                            <span class="icon-bar"></span>
+                            <span class="icon-bar"></span>
+                            <span class="icon-bar"></span>
+                        </button>
+                        <!-- left hand side brand / icon -->
+                        <a class="navbar-brand" href="/">
+                            <span class="glyphicon glyphicon-home"></span>
+                            @if(conference.isEmpty) {
+                                Conference abstracts and submission
+                            }
+                        </a>
+                    </div>
+                    <div class="navbar-collapse collapse">
+                        <ul class="nav navbar-nav">
+                            @conference.map { conf =>
+                                <li class=@if(active.toLowerCase == "conference") {"active"} else {""}>
+                                    <a href="@routes.Application.conference(conf.short)"> @conference.get.short</a>
                                 </li>
-                                <li class="divider"></li>
-                                <li role="presentation" class="dropdown-header">My Settings</li>
-                                <li role="presentation">
-                                    <a role="menuitem" tabindex="-1" href="/password">Change password</a>
-                                    <a role="menuitem" tabindex="-1" href="/mail">Change Email</a>
-                                </li>
-                                <li class="divider"></li>
-                                @if(acc.isAdmin) {
-                                    <li role="presentation" class="dropdown-header">Site Admin</li>
-                                    <li role="presentation">
-                                        <a role="menuitem" tabindex="-1" href="@routes.Application.createConference()">Create Conference</a>
-                                    </li>
-                                    <li role="presentation">
-                                        <a role="menuitem" tabindex="-1" href="@routes.Application.adminAccounts()">Accounts</a>
-                                    </li>
 
-                                    <li class="divider"></li>
+                                @if(conf.schedule != null && conf.schedule.length > 0
+                                        && Json.parse(conf.schedule).asOpt[List[JsValue]] != None
+                                        && Json.parse(conf.schedule).as[List[JsValue]].length > 0) {
+                                    <li class=@if(active.toLowerCase == "conferenceschedule") {"active"} else {""}>
+                                        <a href="@routes.Application.schedule(conf.short)">Schedule</a>
+                                    </li>
                                 }
 
-                                @conference.map { conf =>
-                                  @if(acc.isAdmin || conf.isOwner(acc)) {
-                                      <li role="presentation" class="dropdown-header">Conference Admin</li>
-                                      <li role="presentation">
-                                          <a role="menuitem" tabindex="-1" href="@routes.Application.adminAbstracts(conf.uuid)">Conference Abstracts</a>
-                                      </li>
-                                      <li role="presentation">
-                                          <a role="menuitem" tabindex="-1" href="@routes.Application.adminConference(conf.uuid)">Conference Settings</a>
-                                      </li>
-                                      <li class="divider"></li>
-                                  }
+                                @if(conf.isPublished) {
+                                    <li class=@if(active.toLowerCase == "abstracts") {"active"} else {""}>
+                                        <a href="@routes.Application.abstractsPublic(conf.short)">Abstracts</a>
+                                    </li>
                                 }
 
-                                <li role="presentation">
-                                    <a role="menuitem" tabindex="-1" href="@routes.Accounts.logOut()">Logout</a>
+                            @if(conf.geo != null && conf.geo.length > 0
+                                    && Json.parse(conf.geo).asOpt[List[JsValue]] != None
+                                    && Json.parse(conf.geo).as[List[JsValue]].length > 0){
+                                <li class=@if(active.toLowerCase == "locations") {"active"} else{""} >
+                                    <a href="@routes.Application.locations(conf.short)">Locations</a>
                                 </li>
+                            }
+
+                            @if(conf.geo != null && conf.geo.length > 0
+                                    && Json.parse(conf.geo).asOpt[List[JsValue]] != None
+                                    && Json.parse(conf.geo).as[List[JsValue]].length > 0
+                                    && (Json.parse(conf.geo) \\ "floorplans").size > 0){
+                                <li class=@if(active.toLowerCase == "floorplans") {"active"} else {""}>
+                                    <a href="@routes.Application.floorplans(conf.short)">Floorplans</a>
+                                </li>
+                            }
+
+                            @if(conference.get.isOpen && account.isDefined) {
+                                    <li class=@if(active.toLowerCase == "submission") {"active"} else {""}>
+                                        <a href="@routes.Application.submission(conf.short)">Submission</a>
+                                    </li>
+                                }
+                            }
+
+                            @if(account.isDefined) {
+                                @account.map { acc =>
+                                    <li class=@if(active.toLowerCase == "my abstracts") {"active"} else {""}>
+                                        <a href="@routes.Application.abstractsPrivate()">My Abstracts</a>
+                                    </li>
+                                }
+
+                                @account.map { acc =>
+                                    <li class=@if(active.toLowerCase == "my favourites") {"active"} else {""}>
+                                        <a href="@routes.Application.abstractsFavourite()">My Favourites</a>
+                                    </li>
+                                }
+                            }
+
+                            @if(conference.isEmpty && active) {
+                                @if(!active.toLowerCase == "my abstracts" && !active.toLowerCase == "my favourites") {
+                                    <li class="active"><a>@active</a></li>
+                                }
+                            }
+                        </ul>
+
+                        <ul class="nav navbar-nav navbar-right">
+                            @account.map { acc =>
+                                <li class="dropdown">
+                                    <a href="#" id="usermenu" role="button" class="dropdown-toggle" data-toggle="dropdown">
+                                        @acc.firstName @acc.lastName
+                                        <b class="caret"></b>
+                                    </a>
+
+                                    <ul class="dropdown-menu" role="menu" aria-labelledby="usermenu">
+                                        <li role="presentation">
+                                            <a role="menuitem" tabindex="-1" href="@routes.Application.abstractsPrivate()">My Abstracts</a>
+                                        </li>
+                                        <li class="divider"></li>
+                                        <li role="presentation" class="dropdown-header">My Settings</li>
+                                        <li role="presentation">
+                                            <a role="menuitem" tabindex="-1" href="/password">Change password</a>
+                                            <a role="menuitem" tabindex="-1" href="/mail">Change Email</a>
+                                        </li>
+                                        <li class="divider"></li>
+                                        @if(acc.isAdmin) {
+                                            <li role="presentation" class="dropdown-header">Site Admin</li>
+                                            <li role="presentation">
+                                                <a role="menuitem" tabindex="-1" href="@routes.Application.createConference()">Create Conference</a>
+                                            </li>
+                                            <li role="presentation">
+                                                <a role="menuitem" tabindex="-1" href="@routes.Application.adminAccounts()">Accounts</a>
+                                            </li>
+
+                                            <li class="divider"></li>
+                                        }
+
+                                        @conference.map { conf =>
+                                          @if(acc.isAdmin || conf.isOwner(acc)) {
+                                              <li role="presentation" class="dropdown-header">Conference Admin</li>
+                                              <li role="presentation">
+                                                  <a role="menuitem" tabindex="-1" href="@routes.Application.adminAbstracts(conf.uuid)">Conference Abstracts</a>
+                                              </li>
+                                              <li role="presentation">
+                                                  <a role="menuitem" tabindex="-1" href="@routes.Application.adminConference(conf.uuid)">Conference Settings</a>
+                                              </li>
+                                              <li class="divider"></li>
+                                          }
+                                        }
+
+                                        <li role="presentation">
+                                            <a role="menuitem" tabindex="-1" href="@routes.Accounts.logOut()">Logout</a>
+                                        </li>
+                                    </ul>
+                                </li>
+                            }
+
+                            @if(account.isEmpty && !("login" :: "register" :: Nil).contains(active.toLowerCase)) {
+                                <li><a href="@routes.Accounts.logIn()">Login</a></li>
+                            }
+                        </ul>
+                    </div><!--/.nav-collapse -->
+                </div>
+                @if(!conference.isEmpty){
+                    <div class="row">
+                        <div class="navbar-collapse collapse">
+                            <ul class="nav navbar-nav">
+                                <li class="active"><a href="/">Second row</a></li>
                             </ul>
-                        </li>
-                    }
-
-                    @if(account.isEmpty && !("login" :: "register" :: Nil).contains(active.toLowerCase)) {
-                        <li><a href="@routes.Accounts.logIn()">Login</a></li>
-                    }
-                </ul>
-            </div><!--/.nav-collapse -->
+                        </div>
+                    </div>
+                }
+            </div>
         </div>
     </div>
 

--- a/app/views/template.scala.html
+++ b/app/views/template.scala.html
@@ -93,56 +93,11 @@
                         <!-- left hand side brand / icon -->
                         <a class="navbar-brand" href="/">
                             <span class="glyphicon glyphicon-home"></span>
-                            @if(conference.isEmpty) {
-                                Conference abstracts and submission
-                            }
+                            Conference abstracts and submission
                         </a>
                     </div>
                     <div class="navbar-collapse collapse">
                         <ul class="nav navbar-nav">
-                            @conference.map { conf =>
-                                <li class=@if(active.toLowerCase == "conference") {"active"} else {""}>
-                                    <a href="@routes.Application.conference(conf.short)"> @conference.get.short</a>
-                                </li>
-
-                                @if(conf.schedule != null && conf.schedule.length > 0
-                                        && Json.parse(conf.schedule).asOpt[List[JsValue]] != None
-                                        && Json.parse(conf.schedule).as[List[JsValue]].length > 0) {
-                                    <li class=@if(active.toLowerCase == "conferenceschedule") {"active"} else {""}>
-                                        <a href="@routes.Application.schedule(conf.short)">Schedule</a>
-                                    </li>
-                                }
-
-                                @if(conf.isPublished) {
-                                    <li class=@if(active.toLowerCase == "abstracts") {"active"} else {""}>
-                                        <a href="@routes.Application.abstractsPublic(conf.short)">Abstracts</a>
-                                    </li>
-                                }
-
-                            @if(conf.geo != null && conf.geo.length > 0
-                                    && Json.parse(conf.geo).asOpt[List[JsValue]] != None
-                                    && Json.parse(conf.geo).as[List[JsValue]].length > 0){
-                                <li class=@if(active.toLowerCase == "locations") {"active"} else{""} >
-                                    <a href="@routes.Application.locations(conf.short)">Locations</a>
-                                </li>
-                            }
-
-                            @if(conf.geo != null && conf.geo.length > 0
-                                    && Json.parse(conf.geo).asOpt[List[JsValue]] != None
-                                    && Json.parse(conf.geo).as[List[JsValue]].length > 0
-                                    && (Json.parse(conf.geo) \\ "floorplans").size > 0){
-                                <li class=@if(active.toLowerCase == "floorplans") {"active"} else {""}>
-                                    <a href="@routes.Application.floorplans(conf.short)">Floorplans</a>
-                                </li>
-                            }
-
-                            @if(conference.get.isOpen && account.isDefined) {
-                                    <li class=@if(active.toLowerCase == "submission") {"active"} else {""}>
-                                        <a href="@routes.Application.submission(conf.short)">Submission</a>
-                                    </li>
-                                }
-                            }
-
                             @if(account.isDefined) {
                                 @account.map { acc =>
                                     <li class=@if(active.toLowerCase == "my abstracts") {"active"} else {""}>
@@ -219,13 +174,56 @@
                                 <li><a href="@routes.Accounts.logIn()">Login</a></li>
                             }
                         </ul>
-                    </div><!--/.nav-collapse -->
+                    </div>
                 </div>
+
                 @if(!conference.isEmpty){
                     <div class="row">
+                        <div class="navbar-header col-md-1"></div>
                         <div class="navbar-collapse collapse">
                             <ul class="nav navbar-nav">
-                                <li class="active"><a href="/">Second row</a></li>
+                                @conference.map { conf =>
+                                    <li class=@if(active.toLowerCase == "conference") {"active"} else {""}>
+                                        <a href="@routes.Application.conference(conf.short)"> @conference.get.short</a>
+                                    </li>
+
+                                    @if(conf.schedule != null && conf.schedule.length > 0
+                                    && Json.parse(conf.schedule).asOpt[List[JsValue]] != None
+                                    && Json.parse(conf.schedule).as[List[JsValue]].length > 0) {
+                                        <li class=@if(active.toLowerCase == "conferenceschedule") {"active"} else {""}>
+                                            <a href="@routes.Application.schedule(conf.short)">Schedule</a>
+                                        </li>
+                                    }
+
+                                    @if(conf.isPublished) {
+                                        <li class=@if(active.toLowerCase == "abstracts") {"active"} else {""}>
+                                            <a href="@routes.Application.abstractsPublic(conf.short)">Abstracts</a>
+                                        </li>
+                                    }
+
+                                    @if(conf.geo != null && conf.geo.length > 0
+                                    && Json.parse(conf.geo).asOpt[List[JsValue]] != None
+                                    && Json.parse(conf.geo).as[List[JsValue]].length > 0) {
+                                        <li class=@if(active.toLowerCase == "locations") {"active"} else{""} >
+                                            <a href="@routes.Application.locations(conf.short)">Locations</a>
+                                        </li>
+                                    }
+
+                                    @if(conf.geo != null && conf.geo.length > 0
+                                    && Json.parse(conf.geo).asOpt[List[JsValue]] != None
+                                    && Json.parse(conf.geo).as[List[JsValue]].length > 0
+                                    && (Json.parse(conf.geo) \\ "floorplans").size > 0) {
+                                        <li class=@if(active.toLowerCase == "floorplans") {"active"} else {""}>
+                                            <a href="@routes.Application.floorplans(conf.short)">Floorplans</a>
+                                        </li>
+                                    }
+
+                                    @if(conference.get.isOpen && account.isDefined) {
+                                        <li class=@if(active.toLowerCase == "submission") {"active"} else {""}>
+                                            <a href="@routes.Application.submission(conf.short)">Submission</a>
+                                        </li>
+                                    }
+                                }
                             </ul>
                         </div>
                     </div>

--- a/app/views/template.scala.html
+++ b/app/views/template.scala.html
@@ -112,7 +112,7 @@
 
                         @if(conf.isPublished) {
                             <li class=@if(active.toLowerCase == "abstracts") {"active"} else {""}>
-                            <a href="@routes.Application.abstractsPublic(conf.short)">Abstracts</a>
+                                <a href="@routes.Application.abstractsPublic(conf.short)">Abstracts</a>
                             </li>
                         }
 
@@ -138,22 +138,26 @@
                                 <a href="@routes.Application.submission(conf.short)">Submission</a>
                             </li>
                         }
+                    }
 
+                    @if(account.isDefined) {
                         @account.map { acc =>
-                            <li class=@if(active.toLowerCase == "myabstracts") {"active"} else {""}>
+                            <li class=@if(active.toLowerCase == "my abstracts") {"active"} else {""}>
                                 <a href="@routes.Application.abstractsPrivate()">My Abstracts</a>
                             </li>
                         }
 
                         @account.map { acc =>
-                            <li class=@if(active.toLowerCase == "favouriteabstracts") {"active"} else {""}>
+                            <li class=@if(active.toLowerCase == "my favourites") {"active"} else {""}>
                                 <a href="@routes.Application.abstractsFavourite()">My Favourites</a>
                             </li>
                         }
                     }
 
                     @if(conference.isEmpty && active) {
-                        <li class="active"><a>@active</a></li>
+                        @if(!active.toLowerCase == "my abstracts" && !active.toLowerCase == "my favourites") {
+                            <li class="active"><a>@active</a></li>
+                        }
                     }
                 </ul>
 

--- a/app/views/template.scala.html
+++ b/app/views/template.scala.html
@@ -122,8 +122,9 @@
                         <ul class="nav navbar-nav navbar-right">
                             @account.map { acc =>
                                 <li class="dropdown">
+                                    <!-- Currently there is no other occurrence on the page where the user email address is shown -->
                                     <a href="#" id="usermenu" role="button" class="dropdown-toggle" data-toggle="dropdown">
-                                        @acc.firstName @acc.lastName
+                                        @acc.firstName @acc.lastName (@acc.mail)
                                         <b class="caret"></b>
                                     </a>
 

--- a/conf/routes
+++ b/conf/routes
@@ -5,6 +5,7 @@ GET           /                                               @controllers.Appli
 GET           /contact                                        @controllers.Application.contact
 GET           /impressum                                      @controllers.Application.impressum
 GET           /about                                          @controllers.Application.about
+GET           /datenschutz                                    @controllers.Application.datenschutz
 
 GET           /dashboard/conference                           @controllers.Application.createConference()
 GET           /dashboard/conference/:id                       @controllers.Application.adminConference(id: String)

--- a/conf/routes
+++ b/conf/routes
@@ -63,7 +63,7 @@ GET           /api/abstracts/:id/figures                      @controllers.api.F
 PUT           /api/abstracts/:id/owners                       @controllers.api.Abstracts.setPermissions(id: String)
 GET           /api/abstracts/:id/owners                       @controllers.api.Abstracts.getPermissions(id: String)
 GET           /api/abstracts/:id/favusers                     @controllers.api.Abstracts.favouriteUsers(id: String)
-GET           /api/abstracts/:id/addfavuser                   @controllers.api.Abstracts.addFavUser(id: String)
+PUT           /api/abstracts/:id/addfavuser                   @controllers.api.Abstracts.addFavUser(id: String)
 GET           /api/abstracts/:id/removefavuser                @controllers.api.Abstracts.removeFavUser(id: String)
 GET           /api/abstracts/:id/stateLog                     @controllers.api.Abstracts.listState(id: String)
 PUT           /api/abstracts/:id/state                        @controllers.api.Abstracts.setState(id: String)

--- a/conf/routes
+++ b/conf/routes
@@ -64,7 +64,7 @@ PUT           /api/abstracts/:id/owners                       @controllers.api.A
 GET           /api/abstracts/:id/owners                       @controllers.api.Abstracts.getPermissions(id: String)
 GET           /api/abstracts/:id/favusers                     @controllers.api.Abstracts.favouriteUsers(id: String)
 PUT           /api/abstracts/:id/addfavuser                   @controllers.api.Abstracts.addFavUser(id: String)
-GET           /api/abstracts/:id/removefavuser                @controllers.api.Abstracts.removeFavUser(id: String)
+DELETE        /api/abstracts/:id/removefavuser                @controllers.api.Abstracts.removeFavUser(id: String)
 GET           /api/abstracts/:id/stateLog                     @controllers.api.Abstracts.listState(id: String)
 PUT           /api/abstracts/:id/state                        @controllers.api.Abstracts.setState(id: String)
 

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,4 +1,4 @@
-self._cacheVersion = "v19";
+self._cacheVersion = "v20";
 
 self.resourcesToCache = [
     // Views
@@ -56,6 +56,7 @@ self.resourcesToCache = [
     // view models
     "/assets/javascripts/abstract-list.js",
     "/assets/javascripts/abstract-viewer.js",
+    "/assets/javascripts/abstract-favourite.js",
     "/assets/javascripts/browser.js",
     "/assets/javascripts/conference-schedule.js",
     "/assets/javascripts/config.js",

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -6,6 +6,7 @@ self.resourcesToCache = [
     "/contact",
     "/about",
     "/impressum",
+    "/datenschutz",
     // Assets
     "/assets/manifest.json",
     "/assets/lib/momentjs/moment.js",


### PR DESCRIPTION
This rather extensive PR introduces new features and various bugfixes.

### Fixes
- sanitize code in most of the javascript files. Unsanitized code lead to premature stop of 
  java script execution in more strict browsers like IE and Edge. Fixes #445.
- in the abstract submission, fetch the abstract again from the server 
  to avoid a stale figure caption.
- in the conference administration, topics can now only be added if they contain an
  actual value. Closes #317.
- some of the missing or not-displayed info and error messages in conference administration
  and abstract submission have been fixed.
- template error message on password reset is now properly displayed. Closes #434.

### Features
- In the abstract submission form, the figure caption is now retained, if a figure 
  is deleted and is replaced by a different one. Closes #338.
- in the conference administration, the presentation preferences checkbox was moved to 
  a different position. Closes #341.
- in the abstract submission form, the remaining available characters for text and acknowledgements
  are now available when the page is loaded and not only after the first character has been entered.
  This partially addresses #339.
- in the abstract submission it is now checked, if the abstract title contains LaTeX code and 
  provides a corresponding warning message if this is the case. Closes #397.
- in the abstract submission, any entered DOI in the abstract references is now post processed
  to ideally contain only DOIs of format `10.xxxxx/journal.date.xx`, enabling proper linking later on.
  Partially addresses #339 and closes #201.
- The navigation bar has been restructured and split into two rows. A new navigation item to 
  the external conference home page has been added and the link to favourite abstracts 
  has been renamed to "My Favourites". Closes #436.
- Handlers for `notAuthenticated` and `notAuthorized` have been implemented to
  display appropriate information messages for the user.
- The page now features appropriate forwarding if a user is not logged in. Closes #361.
- Conference links on the "My abstracts" and "My favourites" pages now redirect to the
  abstract overview page of the corresponding conference rather then redirecting to the
  external conference home page. Closes #418.
- any leading or trailing whitespaces in any of the textfields in abstract submission and
  conference administration are now trimmed before the values are saved. Closes #437.
- favouring and disfavouring an abstract now leaves the user at the same page. Closes #417.