### PR TITLE
Conference Settings and Astract issues

### DIFF
--- a/app/assets/javascripts/admin-conference.js
+++ b/app/assets/javascripts/admin-conference.js
@@ -29,6 +29,7 @@ require(["lib/models", "lib/tools", "lib/owned", "knockout", "ko.sortable", "dat
 
         self.otherConfShorts = ko.observable(null);
         self.oldshort = "";
+        self.oldmAbsLeng = 0;
 
         ko.bindingHandlers.datetimepicker = {
             init: function(element, valueAccessor, allBindingsAccessor) {
@@ -181,6 +182,15 @@ require(["lib/models", "lib/tools", "lib/owned", "knockout", "ko.sortable", "dat
           self.conference().groups.remove(data);
         };
 
+        self.checkmAbsLeng = function() {
+            var visible = false;
+            var currVal = self.conference().mAbsLeng();
+            if (currVal !== "" && currVal < self.oldmAbsLeng) {
+                visible = true;
+            }
+            return visible;
+        };
+
         self.makeConferenceObservable = function (conf) {
             conf.makeObservable(["name", "short", "group", "cite", "description", "start", "end", "groups",
                 "deadline", "logo", "thumbnail", "link", "isOpen", "isPublished", "isActive", "hasPresentationPrefs",
@@ -224,6 +234,7 @@ require(["lib/models", "lib/tools", "lib/owned", "knockout", "ko.sortable", "dat
             self.requestConfSpecificField(self.conference().info, "text", self.infoContent);
 
             self.oldShort = self.conference().short();
+            self.oldmAbsLeng = self.conference().mAbsLeng();
         };
 
         self.requestConfSpecificField = function(url, type, setObservable) {

--- a/app/assets/javascripts/admin-conference.js
+++ b/app/assets/javascripts/admin-conference.js
@@ -182,6 +182,17 @@ require(["lib/models", "lib/tools", "lib/owned", "knockout", "ko.sortable", "dat
           self.conference().groups.remove(data);
         };
 
+        self.ensureNumerical = function (data, e) {
+            // Allow backspace etc.
+            var allowedkeyCodes = [8, 9, 13, 27, 35, 36, 37, 38, 39, 46];
+            if (allowedkeyCodes.includes(e.keyCode)) {
+                return true;
+            } else if (e.key.match(/[0-9]/g)) {
+                return true;
+            }
+            return false;
+        };
+
         self.checkmAbsLeng = function() {
             var visible = false;
             var currVal = self.conference().mAbsLeng();
@@ -281,7 +292,7 @@ require(["lib/models", "lib/tools", "lib/owned", "knockout", "ko.sortable", "dat
             if (self.conference().mAbsLeng() === null || self.conference().mAbsLeng() === undefined) {
                 self.conference().mAbsLeng(500);
             }
-            if (self.conference().mAbsLeng() == 0) {
+            if (self.conference().mAbsLeng() === 0 || self.conference().mAbsLeng() === "0") {
                 self.setError("danger", "Abstract length has to be larger than zero");
                 return;
             }

--- a/app/assets/javascripts/editor.js
+++ b/app/assets/javascripts/editor.js
@@ -146,6 +146,16 @@ function (ko, models, tools, msg, validate, owned, astate) {
             }
         };
 
+        self.checkRemoveTopics = function (warnings) {
+            if (self.conference().topics === null || self.conference().topics.length === 0) {
+                warnings.forEach(function (currWarning) {
+                    if (currWarning.match("topic")) {
+                        warnings.splice(warnings.indexOf(currWarning), 1);
+                    }
+                });
+            }
+        };
+
         self.validity = ko.computed(
             function() {
                 var abstract = self.abstract();
@@ -181,6 +191,7 @@ function (ko, models, tools, msg, validate, owned, astate) {
                     };
                 } else {
                     self.checkRemovePresPref(res.warnings);
+                    self.checkRemoveTopics(res.warnings);
                     var nwarn = res.warnings.length;
                     return {
                         ok: false,
@@ -474,7 +485,7 @@ function (ko, models, tools, msg, validate, owned, astate) {
                 self.editedAbstract(self.abstract());
 
                 var hasNoFig = !self.hasAbstractFigures(),
-                    hasFigData = self.newFigure.file ? true : false;
+                    hasFigData = !!self.newFigure.file;
                     if (hasFigData) {
                     // successFig is a function callback
                     self.figureUpload(successFig);

--- a/app/assets/javascripts/editor.js
+++ b/app/assets/javascripts/editor.js
@@ -146,6 +146,16 @@ function (ko, models, tools, msg, validate, owned, astate) {
             }
         };
 
+        self.checkRemoveTopics = function (warnings) {
+            if (self.conference().topics === null || self.conference().topics.length === 0) {
+                warnings.forEach(function (currWarning) {
+                    if (currWarning.match("topic")) {
+                        warnings.splice(warnings.indexOf(currWarning), 1);
+                    }
+                });
+            }
+        };
+
         self.validity = ko.computed(
             function() {
                 var abstract = self.abstract();
@@ -181,6 +191,7 @@ function (ko, models, tools, msg, validate, owned, astate) {
                     };
                 } else {
                     self.checkRemovePresPref(res.warnings);
+                    self.checkRemoveTopics(res.warnings);
                     var nwarn = res.warnings.length;
                     return {
                         ok: false,
@@ -652,6 +663,7 @@ function (ko, models, tools, msg, validate, owned, astate) {
                 var result = validate.abstract(self.abstract());
 
                 self.checkRemovePresPref(result.warnings);
+                self.checkRemoveTopics(res.warnings);
                 if (!result.ok()) {
                     self.setError("Error", "Unable to submit: " +
                         (result.hasErrors() ? result.errors[0] : result.warnings[0]));

--- a/app/assets/javascripts/editor.js
+++ b/app/assets/javascripts/editor.js
@@ -171,8 +171,8 @@ function (ko, models, tools, msg, validate, owned, astate) {
                         handler: function() {}
                     };
                 }
-                var res = validate.abstract(abstract);
-                if (res.ok()) {
+                var result = validate.abstract(abstract);
+                if (result.ok()) {
                     return {
                         ok: true,
                         isError: false,
@@ -181,29 +181,29 @@ function (ko, models, tools, msg, validate, owned, astate) {
                         items: [],
                         handler: function() {}
                     };
-                } else if (res.hasErrors()) {
-                    var nerr = res.errors.length;
+                } else if (result.hasErrors()) {
+                    var nerr = result.errors.length;
                     return {
                         ok: false,
                         isError: true,
                         badgeLevel: self.isAbstractSaved() ? "btn-danger" : " btn-default",
                         badgeText: "" + nerr  + " issue" + (nerr > 1 ? "s" : ""),
                         handler: self.presentValidationResults,
-                        items: res.errors
+                        items: result.errors
                     };
                 } else {
                     // Suppress error, if conference has no presentation preferences
-                    self.checkRemovePresPref(res.warnings);
+                    self.checkRemovePresPref(result.warnings);
                     // Suppress error, if conference has no defined topics
-                    self.checkRemoveTopics(res.warnings);
-                    var nwarn = res.warnings.length;
+                    self.checkRemoveTopics(result.warnings);
+                    var nwarn = result.warnings.length;
                     return {
                         ok: false,
                         isError: false,
                         badgeLevel: "btn-warning",
                         badgeText: "" + nwarn  + " issue" + (nwarn > 1 ? "s" : ""),
                         handler: self.presentValidationResults,
-                        items: res.warnings
+                        items: result.warnings
                     };
                 }
             },

--- a/app/assets/javascripts/editor.js
+++ b/app/assets/javascripts/editor.js
@@ -136,6 +136,7 @@ function (ko, models, tools, msg, validate, owned, astate) {
         );
 
         // validation
+        // If conference has no presentation preferences, suppress messages from validate.js
         self.checkRemovePresPref = function (warnings) {
             if (!self.conference().hasPresentationPrefs) {
                 warnings.forEach(function (currWarning) {
@@ -146,6 +147,7 @@ function (ko, models, tools, msg, validate, owned, astate) {
             }
         };
 
+        // If conference has no topics defined, suppress messages from validate.js
         self.checkRemoveTopics = function (warnings) {
             if (self.conference().topics === null || self.conference().topics.length === 0) {
                 warnings.forEach(function (currWarning) {
@@ -190,7 +192,9 @@ function (ko, models, tools, msg, validate, owned, astate) {
                         items: res.errors
                     };
                 } else {
+                    // Suppress error, if conference has no presentation preferences
                     self.checkRemovePresPref(res.warnings);
+                    // Suppress error, if conference has no defined topics
                     self.checkRemoveTopics(res.warnings);
                     var nwarn = res.warnings.length;
                     return {
@@ -662,7 +666,9 @@ function (ko, models, tools, msg, validate, owned, astate) {
             if (toState === "Submitted") {
                 var result = validate.abstract(self.abstract());
 
+                // Suppress error, if conference has no presentation preferences
                 self.checkRemovePresPref(result.warnings);
+                // Suppress error, if conference has no defined topics
                 self.checkRemoveTopics(result.warnings);
                 if (!result.ok()) {
                     self.setError("Error", "Unable to submit: " +

--- a/app/assets/javascripts/editor.js
+++ b/app/assets/javascripts/editor.js
@@ -146,16 +146,6 @@ function (ko, models, tools, msg, validate, owned, astate) {
             }
         };
 
-        self.checkRemoveTopics = function (warnings) {
-            if (self.conference().topics === null || self.conference().topics.length === 0) {
-                warnings.forEach(function (currWarning) {
-                    if (currWarning.match("topic")) {
-                        warnings.splice(warnings.indexOf(currWarning), 1);
-                    }
-                });
-            }
-        };
-
         self.validity = ko.computed(
             function() {
                 var abstract = self.abstract();
@@ -191,7 +181,6 @@ function (ko, models, tools, msg, validate, owned, astate) {
                     };
                 } else {
                     self.checkRemovePresPref(res.warnings);
-                    self.checkRemoveTopics(res.warnings);
                     var nwarn = res.warnings.length;
                     return {
                         ok: false,
@@ -485,7 +474,7 @@ function (ko, models, tools, msg, validate, owned, astate) {
                 self.editedAbstract(self.abstract());
 
                 var hasNoFig = !self.hasAbstractFigures(),
-                    hasFigData = !!self.newFigure.file;
+                    hasFigData = self.newFigure.file ? true : false;
                     if (hasFigData) {
                     // successFig is a function callback
                     self.figureUpload(successFig);

--- a/app/assets/javascripts/editor.js
+++ b/app/assets/javascripts/editor.js
@@ -146,16 +146,6 @@ function (ko, models, tools, msg, validate, owned, astate) {
             }
         };
 
-        self.checkRemoveTopics = function (warnings) {
-            if (self.conference().topics === null || self.conference().topics.length === 0) {
-                warnings.forEach(function (currWarning) {
-                    if (currWarning.match("topic")) {
-                        warnings.splice(warnings.indexOf(currWarning), 1);
-                    }
-                });
-            }
-        };
-
         self.validity = ko.computed(
             function() {
                 var abstract = self.abstract();
@@ -191,7 +181,6 @@ function (ko, models, tools, msg, validate, owned, astate) {
                     };
                 } else {
                     self.checkRemovePresPref(res.warnings);
-                    self.checkRemoveTopics(res.warnings);
                     var nwarn = res.warnings.length;
                     return {
                         ok: false,
@@ -663,7 +652,6 @@ function (ko, models, tools, msg, validate, owned, astate) {
                 var result = validate.abstract(self.abstract());
 
                 self.checkRemovePresPref(result.warnings);
-                self.checkRemoveTopics(res.warnings);
                 if (!result.ok()) {
                     self.setError("Error", "Unable to submit: " +
                         (result.hasErrors() ? result.errors[0] : result.warnings[0]));

--- a/app/assets/javascripts/editor.js
+++ b/app/assets/javascripts/editor.js
@@ -652,7 +652,6 @@ function (ko, models, tools, msg, validate, owned, astate) {
                 var result = validate.abstract(self.abstract());
 
                 self.checkRemovePresPref(result.warnings);
-                self.checkRemoveTopics(result.warnings);
                 if (!result.ok()) {
                     self.setError("Error", "Unable to submit: " +
                         (result.hasErrors() ? result.errors[0] : result.warnings[0]));

--- a/app/assets/javascripts/editor.js
+++ b/app/assets/javascripts/editor.js
@@ -146,6 +146,16 @@ function (ko, models, tools, msg, validate, owned, astate) {
             }
         };
 
+        self.checkRemoveTopics = function (warnings) {
+            if (self.conference().topics === null || self.conference().topics.length === 0) {
+                warnings.forEach(function (currWarning) {
+                    if (currWarning.match("topic")) {
+                        warnings.splice(warnings.indexOf(currWarning), 1);
+                    }
+                });
+            }
+        };
+
         self.validity = ko.computed(
             function() {
                 var abstract = self.abstract();
@@ -181,6 +191,7 @@ function (ko, models, tools, msg, validate, owned, astate) {
                     };
                 } else {
                     self.checkRemovePresPref(res.warnings);
+                    self.checkRemoveTopics(res.warnings);
                     var nwarn = res.warnings.length;
                     return {
                         ok: false,
@@ -652,6 +663,7 @@ function (ko, models, tools, msg, validate, owned, astate) {
                 var result = validate.abstract(self.abstract());
 
                 self.checkRemovePresPref(result.warnings);
+                self.checkRemoveTopics(result.warnings);
                 if (!result.ok()) {
                     self.setError("Error", "Unable to submit: " +
                         (result.hasErrors() ? result.errors[0] : result.warnings[0]));

--- a/app/assets/javascripts/editor.js
+++ b/app/assets/javascripts/editor.js
@@ -663,6 +663,7 @@ function (ko, models, tools, msg, validate, owned, astate) {
                 var result = validate.abstract(self.abstract());
 
                 self.checkRemovePresPref(result.warnings);
+                self.checkRemoveTopics(result.warnings);
                 if (!result.ok()) {
                     self.setError("Error", "Unable to submit: " +
                         (result.hasErrors() ? result.errors[0] : result.warnings[0]));

--- a/app/service/ConferenceService.scala
+++ b/app/service/ConferenceService.scala
@@ -114,7 +114,7 @@ class ConferenceService() extends PermissionsBase {
       val queryStr =
         """SELECT DISTINCT c FROM Conference c
            INNER JOIN c.abstracts a
-           INNER JOIN a.owners af
+           INNER JOIN a.favUsers af
            WHERE af.uuid = :uuid
            ORDER BY c.startDate DESC"""
       val query : TypedQuery[Conference] = em.createQuery(queryStr, classOf[Conference])

--- a/app/views/dashboard/admin/conference.scala.html
+++ b/app/views/dashboard/admin/conference.scala.html
@@ -218,13 +218,13 @@
                     <label for="mAbsLen" class="col-sm-4">Max. Abs. Len. (<@Model.getLimit[Abstract]("text"))</label>
                     <div class="col-sm-6">
                         <input type="text" class="form-control" id="mAbsLen"
-                        placeholder="Maximum Abstract Length (chars)" data-bind="value:mAbsLeng, valueUpdate:'afterkeydown'">
+                        placeholder="Maximum Abstract Length (chars)" data-bind="value:mAbsLeng, valueUpdate:'afterkeydown', event: { keypress: $root.ensureNumerical }">
                     </div>
                 </div>
 
                 <div class="form-group">
                     <div class="col-sm-offset-2 col-sm-10 alert alert-danger fade in out" data-bind="visible: $root.checkmAbsLeng()">
-                        Changing to shorter abstract length causes cut-offs for already craeted abstracts exceeding this new length!
+                        Changing to shorter abstract length causes cut-offs for already created abstracts exceeding this new length!
                     </div>
                 </div>
 
@@ -232,7 +232,7 @@
                     <label for="mFigs" class="col-sm-4">Max. Figs.</label>
                     <div class="col-sm-6">
                         <input type="text" class="form-control" id="mFigs"
-                        placeholder="Maximum Number Of Figures" data-bind="value: mFigs, valueUpdate: 'afterkeydown'">
+                        placeholder="Maximum Number Of Figures" data-bind="value: mFigs, valueUpdate: 'afterkeydown', event: { keypress: $root.ensureNumerical }">
                     </div>
                 </div>
 

--- a/app/views/dashboard/admin/conference.scala.html
+++ b/app/views/dashboard/admin/conference.scala.html
@@ -223,6 +223,12 @@
                 </div>
 
                 <div class="form-group">
+                    <div class="col-sm-offset-2 col-sm-10 alert alert-danger fade in out" data-bind="visible: $root.checkmAbsLeng()">
+                        Changing to shorter abstract length causes cut-offs for already craeted abstracts exceeding this new length!
+                    </div>
+                </div>
+
+                <div class="form-group">
                     <label for="mFigs" class="col-sm-4">Max. Figs.</label>
                     <div class="col-sm-6">
                         <input type="text" class="form-control" id="mFigs"

--- a/app/views/template.scala.html
+++ b/app/views/template.scala.html
@@ -220,7 +220,7 @@
 
                                     @if(conf.link != null && conf.link.length > 0) {
                                         <li>
-                                            <a href="@conf.link">&#x1F5D7; Conference home</a>
+                                            <a href="@conf.link"><span class="glyphicon glyphicon-new-window"></span> Conference home</a>
                                         </li>
                                     }
 

--- a/app/views/template.scala.html
+++ b/app/views/template.scala.html
@@ -220,7 +220,7 @@
 
                                     @if(conf.link != null && conf.link.length > 0) {
                                         <li>
-                                            <a href="@conf.link">Conference home</a>
+                                            <a href="@conf.link">&#x1F5D7; Conference home</a>
                                         </li>
                                     }
 


### PR DESCRIPTION
This PR fixes some error messages and issues arising with conference settings and abstracts.

Fixes

- Favourite abstracts are now correctly listed. Closes #431.

- External link icon for the conference home button in the navigation bar. Closes #446.

- A warning message is displayed, if the abstract length is reduced in the conference settings. Closes #427. 

- Non numerical input in the conference settings for 'maximum abstract length' and 'number of figures' is suppressed. Related to issue #426.

- Abstracts saving and submission is possible, if no topics are defined for a conference. Fixes #443. 