### PR TITLE
Issue fixes B for release 2019

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,22 +7,23 @@ until the next release.
 
 ## Features
 - Added docker support to the project. GCA-Web can now also be run using docker containers.
-  The latest buids can be found at [dockerhub](https://hub.docker.com/r/gnode/gca/builds).
+  The latest builds can be found at [dockerhub](https://hub.docker.com/r/gnode/gca/builds).
 - Added a "Favourite Abstracts" feature to the page. Viewed abstracts can now be
   marked and a list of favoured abstracts can be separately accessed.
 - Login behavior has been changed to support page redirecting to the original page after 
   a login has occurred. See issue #361 for details.
 - Due to previously added features like "Schedule" or "Location" the navigation bar
   has been restructured to a two row display to accommodate all new features.
+  See also issue #446 for details.
 - Various smaller changes in behavior have been made to the conference administration page.
-  See issues #341 and #437 for details.
+  See issues #341, #426, #427 and #437 for details.
 - Various smaller changes in behavior have been made to the abstract submission page.
-  See issues #201, #338, #339, #397 and #437 for details.
+  See issues #201, #288, #338, #339, #397, #437 and #443 for details.
 
 ## Fixes
 - JavaScript code files have been sanitized. Unsanitized code lead to premature stop of 
   JavaScript execution in more strict browsers like IE and Edge. See #445 for details.
-- Various fixes have been applied to the abstract submission. See #444 and #439 for details.
+- Various fixes have been applied to the abstract submission. See #438, #439 and #444 for details.
 - Various fixes have been applied to the conference administration. See #317, #425, #439 and #444 for details 
 - The site now displays pages within the GCA-Web scope on notAuthenticated and notAuthorized 
   access. See #444 for details.

--- a/app/assets/javascripts/editor.js
+++ b/app/assets/javascripts/editor.js
@@ -840,7 +840,8 @@ function (ko, models, tools, msg, validate, owned, astate) {
                     "<b> <u> Please note that abstract submission does not replace conference registration!</u> <br/>" +
                     "All abstract submitters also have to register for the conference.</b><br/>" +
                     "To register please go to: <a target=\"_blank\" href=\"" +
-                    self.conference().link + "\">" + self.conference().link + "</a>"
+                    self.conference().link + "\"><span class=\"glyphicon glyphicon-new-window\"></span> " +
+                    self.conference().link + "</a>"
                 );
             }
         };

--- a/app/assets/javascripts/editor.js
+++ b/app/assets/javascripts/editor.js
@@ -694,6 +694,9 @@ function (ko, models, tools, msg, validate, owned, astate) {
 
         self.doWithdrawAbstract = function () {
             self.doChangeState("Withdrawn");
+
+            // Cleanup any leftover messages
+            self.clearMessage();
         };
 
         self.action = ko.computed(

--- a/app/assets/javascripts/editor.js
+++ b/app/assets/javascripts/editor.js
@@ -795,7 +795,7 @@ function (ko, models, tools, msg, validate, owned, astate) {
                     "<li>Nothing will be stored on the server before the abstract is saved for" +
                     "    the first time, so it is ok to play around and explore this editor.</li>" +
                     "<li>After entering at least the abstract title, click the <b>Save</b> button" +
-                    "    to store the abstract on the server. Subsequent changes will the be " +
+                    "    to store the abstract on the server. Subsequent changes will then be " +
                     "    saved automatically.</li>" +
                     "<li>The 'Validation' field above indicates if there are issues with the" +
                     "    required content of the abstract. Clicking on the <i>issues</i> button will " +

--- a/app/assets/javascripts/editor.js
+++ b/app/assets/javascripts/editor.js
@@ -71,9 +71,8 @@ function (ko, models, tools, msg, validate, owned, astate) {
                 var checkTitle = /.*\$.*\$.*/;
                 if (self.editedAbstract() && self.editedAbstract().title() && checkTitle.test(self.editedAbstract().title())) {
                     return "Please avoid using LaTeX code in the abstract title";
-                } else {
-                    return "";
                 }
+                return "";
             },
             self
         );

--- a/app/assets/javascripts/editor.js
+++ b/app/assets/javascripts/editor.js
@@ -807,6 +807,7 @@ function (ko, models, tools, msg, validate, owned, astate) {
                     self.setWarning("Abstract unlocked",
                         "<ul>" +
                         "<li>Autosave is again enabled, changes will be stored directly on the server.</li>" +
+                        "<li>This abstract is <b>not submitted</b> yet.</li>" +
                         "<li>Abstract must be re-submitted before the deadline. If the abstract is not submitted, " +
                         "    it will not be considered for the conference.</li>" +
                         "</ul>"
@@ -816,6 +817,7 @@ function (ko, models, tools, msg, validate, owned, astate) {
                         "Abstract is saved",
                         "<ul>" +
                         "<li>Autosave is enabled, i.e. changes are stored automatically on the server.</li>" +
+                        "<li>This abstract is <b>not submitted</b> yet.</li>" +
                         "<li>Once the Validation field shows 'Ok', you can click the " +
                         "    <b>Submit</b> button to submit it. Submitted abstracts can" +
                         "    be modified until the deadline. </li>" +

--- a/app/assets/javascripts/editor.js
+++ b/app/assets/javascripts/editor.js
@@ -196,6 +196,20 @@ function (ko, models, tools, msg, validate, owned, astate) {
                     // Suppress error, if conference has no defined topics
                     self.checkRemoveTopics(result.warnings);
                     var nwarn = result.warnings.length;
+
+                    // Return result Ok, if no warnings are left after preference and
+                    // topics warnings have been suppressed.
+                    if (nwarn !== null && nwarn !== undefined && nwarn === 0) {
+                        return {
+                            ok: true,
+                            isError: false,
+                            badgeLevel: "btn-success",
+                            badgeText: "Ok",
+                            items: [],
+                            handler: function() {}
+                        };
+                    }
+
                     return {
                         ok: false,
                         isError: false,

--- a/app/assets/javascripts/editor.js
+++ b/app/assets/javascripts/editor.js
@@ -439,6 +439,9 @@ function (ko, models, tools, msg, validate, owned, astate) {
         };
 
         self.doSaveAbstract = function (abstract) {
+            // Clean slate for new messages
+            self.clearMessage();
+
             if (!(abstract instanceof models.ObservableAbstract)) {
                 abstract = self.abstract();
             }
@@ -505,8 +508,6 @@ function (ko, models, tools, msg, validate, owned, astate) {
 
                 if (firstSave) {
                     self.showHelp();
-                } else {
-                    self.clearMessage();
                 }
             }
 

--- a/app/assets/javascripts/lib/models.js
+++ b/app/assets/javascripts/lib/models.js
@@ -1136,21 +1136,22 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
 
                 // Post process doi. Remove any leading doi link parts that hinder rendering later on.
                 var doiValue = model.doi();
+                if (doiValue !== null && doiValue !== undefined) {
+                    // First remove leading http or https
+                    doiValue = doiValue.replace(/^https:\/\//, "").replace(/http:\/\//, "");
 
-                // First remove leading http or https
-                doiValue = doiValue.replace(/^https:\/\//, "").replace(/http:\/\//, "");
+                    // Then search and replace DOI variant hierarchical URL parts
+                    var checkA = /^dx.doi.org\//;
+                    var checkB = /^doi.org\//;
+                    var checkC = /^doi:/;
 
-                // Then search and replace DOI variant hierarchical URL parts
-                var checkA = /^dx.doi.org\//;
-                var checkB = /^doi.org\//;
-                var checkC = /^doi:/;
-
-                if (checkA.test(doiValue)) {
-                    model.doi(doiValue.replace(checkA, ""));
-                } else if (checkB.test(doiValue)) {
-                    model.doi(doiValue.replace(checkB, ""));
-                } else if (checkC.test(doiValue)) {
-                    model.doi(doiValue.replace(checkC, ""));
+                    if (checkA.test(doiValue)) {
+                        model.doi(doiValue.replace(checkA, ""));
+                    } else if (checkB.test(doiValue)) {
+                        model.doi(doiValue.replace(checkB, ""));
+                    } else if (checkC.test(doiValue)) {
+                        model.doi(doiValue.replace(checkC, ""));
+                    }
                 }
 
                 obj.references.push(model.toObject());

--- a/app/service/AbstractService.scala
+++ b/app/service/AbstractService.scala
@@ -380,8 +380,8 @@ class AbstractService(figPath: String) extends PermissionsBase {
       if (accountChecked == null)
         throw new EntityNotFoundException("Unable to find account with uuid = " + account.uuid)
 
-      val isOwner = abstrChecked.owners.contains(accountChecked)
-      val isConfOwner = abstrChecked.conference.owners.contains(accountChecked)
+      val isOwner = abstrChecked.isOwner(accountChecked)
+      val isConfOwner = abstrChecked.conference.isOwner(accountChecked)
       val isAdmin = accountChecked.isAdmin
       if (! (isOwner || isConfOwner || isAdmin))
         throw new IllegalAccessException("No permissions for abstract with uuid = " + abstr.uuid)
@@ -441,6 +441,7 @@ class AbstractService(figPath: String) extends PermissionsBase {
     }
     get(abstrUpdated.uuid)
   }
+
   /**
     * Remove a favourite user from an abstract.
     *
@@ -456,7 +457,6 @@ class AbstractService(figPath: String) extends PermissionsBase {
     }
     get(abstrUpdated.uuid)
   }
-
 
   /**
    * Delete an abstract.

--- a/app/service/AbstractService.scala
+++ b/app/service/AbstractService.scala
@@ -479,8 +479,8 @@ class AbstractService(figPath: String) extends PermissionsBase {
       if (abstrChecked == null)
         throw new EntityNotFoundException("Unable to find abstract with uuid = " + id)
 
-      val isOwner = abstrChecked.owners.contains(accountChecked)
-      val isConfOwner = abstrChecked.conference.owners.contains(accountChecked)
+      val isOwner = abstrChecked.isOwner(accountChecked)
+      val isConfOwner = abstrChecked.conference.isOwner(accountChecked)
       val isAdmin = accountChecked.isAdmin
       if (! (isOwner || isConfOwner || isAdmin))
         throw new IllegalAccessException("No permissions for abstract with uuid = " + id)

--- a/app/views/signup.scala.html
+++ b/app/views/signup.scala.html
@@ -17,11 +17,17 @@
       @password(form("password"), "Password", icon = "key")
 
       <div class="form-group">
+
+        <div class="jumbotron">
+          By registering, you agree to our
+          <a href="https://web.gin.g-node.org/G-Node/Info/wiki/Terms+of+Use">Terms of Use</a> and
+          <a href="@routes.Application.datenschutz">Data Processing Policy</a>.
+        </div>
+
         <div>
           <button id="submit" type="submit" value="submit" class="btn btn-lg btn-primary btn-block">Submit</button>
         </div>
       </div>
     }
   </fieldset>
-
 }

--- a/app/views/signup.scala.html
+++ b/app/views/signup.scala.html
@@ -20,7 +20,7 @@
 
         <div class="jumbotron">
           By registering, you agree to our
-          <a href="https://web.gin.g-node.org/G-Node/Info/wiki/Terms+of+Use">Terms of Use</a> and
+          <a onclick="window.open('https://web.gin.g-node.org/G-Node/Info/wiki/Terms+of+Use')" href="">Terms of Use</a> and
           <a href="@routes.Application.datenschutz">Data Processing Policy</a>.
         </div>
 


### PR DESCRIPTION
This PR
- fixes not displayed error messages on the abstract submission page, see issue #438.
- fixes a submission page JavaScript crash if a reference contains an empty DOI.
- Updates info messages on the abstract submission page; closes #228.
- Now uses the `abstract.isOwner` method in all `AbstractService.scala` methods to address the elusive issue #430.
- The signup page now features links to "Terms of Use" and "Datenschutz".
- fixes the validation result display on the abstract submission page if no topics or preferences are available. Closes #453.
