### PR TITLE
Favourite abstract style updates

### DIFF
--- a/app/assets/stylesheets/layout.less
+++ b/app/assets/stylesheets/layout.less
@@ -160,15 +160,14 @@ body {
   }
 
   .favour{
-    color: white !important;
-    background-color: gold !important;
+    color: @color-dark-gray-dark !important;
+    background-color: white !important;
     border-radius: 4px;
   }
   .disfavour{
-    color: white;
-    background-color: darkred;
+    color: rgb(184, 134, 11);
+    background-color: rgb(255, 250, 120);
     border-radius: 4px;
-    border: none;
   }
 
   .abstract-text {

--- a/app/assets/stylesheets/layout.less
+++ b/app/assets/stylesheets/layout.less
@@ -164,6 +164,7 @@ body {
     background-color: white !important;
     border-radius: 4px;
   }
+
   .disfavour{
     color: rgb(184, 134, 11);
     background-color: rgb(255, 250, 120);
@@ -409,4 +410,34 @@ body {
 
 .tab-content {
   margin-top: 10px;
+}
+
+ /* Tooltip container */
+.gn-tooltip {
+  color: black;
+}
+
+/* Tooltip text */
+.gn-tooltip .gn-tooltiptext {
+  visibility: hidden;
+  background-color: #555;
+  color: #fff;
+  text-align: center;
+  padding: 5px;
+  border-radius: 5px;
+
+  /* Position the tooltip text */
+  position: fixed;
+  z-index: 1;
+  margin-top: -60px;
+
+  /* Fade in tooltip */
+  opacity: 0;
+  transition: opacity 0.3s;
+}
+
+/* Show the tooltip text when you mouse over the tooltip container */
+.gn-tooltip:hover .gn-tooltiptext {
+  visibility: visible;
+  opacity: 1;
 }

--- a/app/views/abstractlist.scala.html
+++ b/app/views/abstractlist.scala.html
@@ -86,10 +86,10 @@
 
             @if(account.isDefined) {
                 <li data-bind="visible: !$root.isFavouriteAbstract()">
-                    <a class="favour" data-bind="click: $root.favourAbstract">&#9733</a>
+                    <a class="favour" data-bind="click: $root.favourAbstract" href="">&#9733</a>
                 </li>
                 <li data-bind="visible: $root.isFavouriteAbstract">
-                    <a class="disfavour" data-bind="click: $root.disfavourAbstract">&#9733</a>
+                    <a class="disfavour" data-bind="click: $root.disfavourAbstract" href="">&#9733</a>
                 </li>
             }
 

--- a/app/views/abstractlist.scala.html
+++ b/app/views/abstractlist.scala.html
@@ -86,10 +86,16 @@
 
             @if(account.isDefined) {
                 <li data-bind="visible: !$root.isFavouriteAbstract()">
-                    <a class="favour" data-bind="click: $root.favourAbstract" href="">&#9733</a>
+                    <a class="favour gn-tooltip" data-bind="click: $root.favourAbstract" href="">
+                        &#9733
+                        <span class="gn-tooltiptext">Add abstract to favourites</span>
+                    </a>
                 </li>
                 <li data-bind="visible: $root.isFavouriteAbstract">
-                    <a class="disfavour" data-bind="click: $root.disfavourAbstract" href="">&#9733</a>
+                    <a class="disfavour gn-tooltip" data-bind="click: $root.disfavourAbstract" href="">
+                        &#9733
+                        <span class="gn-tooltiptext">Remove abstract from favourites</span>
+                    </a>
                 </li>
             }
 

--- a/app/views/dashboard/favouriteabstracts.scala.html
+++ b/app/views/dashboard/favouriteabstracts.scala.html
@@ -48,11 +48,11 @@
                     <span data-bind="text: cite"></span>
                 </div>
                 <ul id="abstract-list" class="list-group" data-bind="foreach: abstracts">
-                    <a data-bind="attr: { href: createLink().absLink }">
-                        <li id="abstract-list-item" class="list-group-item abstract">
+                    <li id="abstract-list-item" class="list-group-item abstract">
+                        <a data-bind="attr: { href: createLink().absLink }">
                             <span data-bind="text: title"></span>
-                        </li>
-                    </a>
+                        </a>
+                    </li>
                 </ul>
             </div>
         </div>

--- a/app/views/dashboard/favouriteabstracts.scala.html
+++ b/app/views/dashboard/favouriteabstracts.scala.html
@@ -20,7 +20,7 @@
     <!-- If no Favourites -->
     <div data-bind="if: noFavouriteAbstracts">
         <div class="alert alert-info fade in out">
-            <h4>You have no favourite abstracts yet. Click the star button shown for abstracts to add them.</h4>
+            <h4>You have no favourite abstracts yet. Click the star button on an abstract to add it.</h4>
         </div>
     </div>
 


### PR DESCRIPTION
This PR updates some of the favourite abstract style features:
- the message when a user has no favourite abstracts has been slightly changed.
- the favour / unfavour button now come in less intense colors.
- the favour / unfavour button now uses the proper link mouse icon when hovering over.
- the favour / unfavour button now feature a tooltip elaborating on favourite abstracts. Closes #420.
