### PR TITLE
Favourite Abstracts Conference List

### DIFF
--- a/app/assets/javascripts/abstract-list.js
+++ b/app/assets/javascripts/abstract-list.js
@@ -291,7 +291,7 @@ require(["lib/models", "lib/tools", "knockout", "sammy", "lib/offline"], functio
         };
 
         self.isFavourite = function(abstract) {
-            self.isFavouriteAbstract($.inArray(abstract.uuid, self.favAbsArr) >= 0);
+            self.isFavouriteAbstract(self.favAbsArr.includes(abstract.uuid, 0));
         };
 
         self.getFavourites = function() {
@@ -303,12 +303,12 @@ require(["lib/models", "lib/tools", "knockout", "sammy", "lib/offline"], functio
                     self.favAbsArr.push(obj);
                 });
                 for (var i = 0; i < self.abstractsData.length; i++) {
-                    var isFav = $.inArray(self.abstractsData[i].uuid, self.favAbsArr) >= 0;
+                    var isFav = self.favAbsArr.includes(self.abstractsData[i].uuid, 0);
                     self.favs.push(isFav);
                 }
 
                 if (self.selectedAbstract()) {
-                    self.isFavouriteAbstract($.inArray(self.selectedAbstract().uuid, self.favAbsArr) >= 0);
+                    self.isFavouriteAbstract(self.favAbsArr.includes(self.selectedAbstract().uuid, 0));
                 }
             }
         };

--- a/app/assets/javascripts/admin-abstracts.js
+++ b/app/assets/javascripts/admin-abstracts.js
@@ -145,6 +145,17 @@ require(["lib/models", "lib/tools", "lib/astate", "knockout"], function(models, 
             self.selectedAbstract();
         };
 
+        self.editorNoteCharactersLeft = ko.computed(
+            function () {
+                if (self.note()) {
+                    return 255 - self.note().length;
+                } else {
+                    return 255;
+                }
+            },
+            self
+        );
+
         self.mkAuthorList = function(abstract) {
             if (abstract.authors.length < 1) {
                 return "";

--- a/app/assets/javascripts/admin-abstracts.js
+++ b/app/assets/javascripts/admin-abstracts.js
@@ -23,6 +23,8 @@ require(["lib/models", "lib/tools", "lib/astate", "knockout"], function(models, 
         self.abstracts = ko.observableArray(null);
         self.abstractNumbers = ko.observable({ total: 0, active: 0 });
 
+        self.note = ko.observable(null);
+
         // State related things
         self.stateHelper = astate.changeHelper;
         self.selectedAbstract = ko.observable(null);
@@ -131,16 +133,15 @@ require(["lib/models", "lib/tools", "lib/astate", "knockout"], function(models, 
 
         self.beginStateChange = function(abstract) {
             // Reset the message box
-            $("#note").val("");
+            self.note("");
             $("#state-dialog").modal("show");
             self.selectedAbstract(abstract);
         };
 
         self.finishStateChange = function() {
-            var note = $("#note").val();
             var state = $("#state-dialog").find("select").val();
 
-            self.setState(self.selectedAbstract(), state, note);
+            self.setState(self.selectedAbstract(), state, self.note());
             self.selectedAbstract();
         };
 

--- a/app/controllers/api/Abstracts.scala
+++ b/app/controllers/api/Abstracts.scala
@@ -266,15 +266,7 @@ extends Silhouette[Login, CachedCookieAuthenticator] {
       for (acc <- favUsers) yield accountFormat.writes(acc)
     ))
   }
-  /**
-    * Check, whether current user is has the abstract as a favourite.
-    *
-    * @return a list of updated permissions (accounts) as JSON
-    */
-  def isFavouriteUser(id: String) = SecuredAction { implicit request =>
-    val abstr = abstractService.get(id)
-    Ok(abstr.favUsers.contains(request.identity.account).toString)
-  }
+
   /**
     * Add the logged in user to the favourite users list of an abstract.
     *

--- a/app/controllers/api/Abstracts.scala
+++ b/app/controllers/api/Abstracts.scala
@@ -140,6 +140,19 @@ extends Silhouette[Login, CachedCookieAuthenticator] {
   }
 
   /**
+    * List all favourite abstracts for a given conference and a given user
+    *
+    * @return All (accessible) favourite abstracts for a given user.
+    */
+  def listFavUuidByConf(conferenceId: String) = SecuredAction { implicit request =>
+    val conference = conferenceService.get(conferenceId)
+    val abstracts = abstractService.listIsFavourite(conference, request.identity.account)
+    Ok(Json.toJson(
+      for (abs <- abstracts) yield abs.uuid
+    ))
+  }
+
+  /**
    * An abstract info by id.
    *
    * @param id The id of the abstract.

--- a/app/service/AbstractService.scala
+++ b/app/service/AbstractService.scala
@@ -172,6 +172,20 @@ class AbstractService(figPath: String) extends PermissionsBase {
     }
   }
 
+  def listIsFavourite(conference: Conference, account: Account) : Seq[Abstract] = {
+    query { em =>
+      val queryStr =
+        """SELECT DISTINCT a FROM Abstract a
+           LEFT JOIN FETCH a.favUsers f
+           LEFT JOIN FETCH a.conference c
+           WHERE c.uuid = :ConfUuid AND f.uuid = :FavUserUuid
+           ORDER BY a.sortId, a.title"""
+      val query: TypedQuery[Abstract] = em.createQuery(queryStr, classOf[Abstract])
+      query.setParameter("ConfUuid", conference.uuid)
+      query.setParameter("FavUserUuid", account.uuid)
+      asScalaBuffer(query.getResultList)
+    }
+  }
 
   def isFavourite(conference: Conference, account: Account) : Seq[Abstract] = {
     query { em =>

--- a/app/views/abstractlist.scala.html
+++ b/app/views/abstractlist.scala.html
@@ -59,6 +59,9 @@
             <div class="abstract">
                 <div class="sortId" data-bind="html: $parent.makeAbstractID($data)"></div>
                 <div class="box">
+                    @if(account.isDefined) {
+                        <div class="pull-right" data-bind="visible: $parent.favs()[$index()]">&#9733</div>
+                    }
                     <h4 class="list-group-item-heading" data-bind="text: title"></h4>
                     <div class="list-group-item-text">
                         <ul class="authors" data-bind="foreach: authors">
@@ -91,7 +94,7 @@
                         <span class="gn-tooltiptext">Add abstract to favourites</span>
                     </a>
                 </li>
-                <li data-bind="visible: $root.isFavouriteAbstract">
+                <li data-bind="visible: $root.isFavouriteAbstract()">
                     <a class="disfavour gn-tooltip" data-bind="click: $root.disfavourAbstract" href="">
                         &#9733
                         <span class="gn-tooltiptext">Remove abstract from favourites</span>

--- a/app/views/dashboard/admin/abstracts.scala.html
+++ b/app/views/dashboard/admin/abstracts.scala.html
@@ -111,8 +111,11 @@
                             <option data-bind="value: $data, text: $data"></option>
                         </select>
 
-                        <label for="note">Message:</label>
-                        <textarea class="form-control" id="note" cols="80" rows="3"></textarea>
+                        <label for="noteId">Message:</label>
+                        <textarea class="form-control" id="noteId"
+                            data-bind="value: $root.note, valueUpdate: 'afterkeydown'"
+                            cols="80" rows="3" maxlength="255">
+                        </textarea>
                     </div>
 
                     <div class="modal-footer">

--- a/app/views/dashboard/admin/abstracts.scala.html
+++ b/app/views/dashboard/admin/abstracts.scala.html
@@ -116,6 +116,10 @@
                             data-bind="value: $root.note, valueUpdate: 'afterkeydown'"
                             cols="80" rows="3" maxlength="255">
                         </textarea>
+                        <div>
+                            <span>Characters left: </span>
+                            <span data-bind="text: $root.editorNoteCharactersLeft"></span>
+                        </div>
                     </div>
 
                     <div class="modal-footer">

--- a/conf/routes
+++ b/conf/routes
@@ -84,6 +84,7 @@ GET           /api/user/:id/abstracts                         @controllers.api.A
 GET           /api/user/:id/favouriteabstracts                @controllers.api.Abstracts.listFavByAccount(id: String)
 GET           /api/user/self/conferences/:id/abstracts        @controllers.api.Abstracts.listOwn(id: String)
 GET           /api/user/self/conferences/:id/favouriteabstracts        @controllers.api.Abstracts.listFavByConf(id: String)
+GET           /api/user/self/conferences/:id/favabstractuuids       @controllers.api.Abstracts.listFavUuidByConf(id: String)
 GET           /api/user/self/conferences                      @controllers.api.Conferences.listWithOwnAbstracts
 GET           /api/user/self/conffavouriteabstracts           @controllers.api.Conferences.listWithFavAbstracts
 GET           /api/user/self/abstract/:id/isfavuser           @controllers.api.Abstracts.isFavouriteUser(id: String)

--- a/conf/routes
+++ b/conf/routes
@@ -87,7 +87,6 @@ GET           /api/user/self/conferences/:id/favouriteabstracts        @controll
 GET           /api/user/self/conferences/:id/favabstractuuids       @controllers.api.Abstracts.listFavUuidByConf(id: String)
 GET           /api/user/self/conferences                      @controllers.api.Conferences.listWithOwnAbstracts
 GET           /api/user/self/conffavouriteabstracts           @controllers.api.Conferences.listWithFavAbstracts
-GET           /api/user/self/abstract/:id/isfavuser           @controllers.api.Abstracts.isFavouriteUser(id: String)
 
 
 # Auth -----------------------------------------------------------------------------------------------------------------

--- a/test/controller/AbstractsCtrlTest.scala
+++ b/test/controller/AbstractsCtrlTest.scala
@@ -180,6 +180,31 @@ class AbstractsCtrlTest extends BaseCtrlTest {
   }
 
   @Test
+  def testListFavUuidByConf() {
+
+    val cid = assets.conferences(0).uuid
+    val reqNoAuth = FakeRequest(GET, s"/api/user/self/conferences/$cid/favabstractuuids")
+
+    val reqNoAuthResult = routeWithErrors(AbstractsCtrlTest.app, reqNoAuth).get
+    assert(status(reqNoAuthResult) == UNAUTHORIZED)
+
+    val reqAuth = reqNoAuth.withCookies(cookie)
+    val reqAuthResult = route(AbstractsCtrlTest.app, reqAuth).get
+    assert(status(reqAuthResult) == OK)
+
+    val loadedJSONAlice = contentAsJson(reqAuthResult).as[Array[String]]
+    assert(loadedJSONAlice.length == 0)
+
+    val bobCookie = getCookie(assets.bob, "testtest")
+    val reqBob = reqNoAuth.withCookies(bobCookie)
+    val reqBobResult = route(AbstractsCtrlTest.app, reqBob).get
+    assert(status(reqAuthResult) == OK)
+
+    val loadedJSONBob = contentAsJson(reqBobResult).as[Array[String]]
+    assert(loadedJSONBob.length == assets.abstracts.size)
+  }
+
+  @Test
   def testDelete() {
     val absUUID = assets.abstracts(0).uuid
     val reqNoAuth = FakeRequest(DELETE, s"/api/abstracts/$absUUID")

--- a/test/service/AbstractServiceTest.scala
+++ b/test/service/AbstractServiceTest.scala
@@ -64,6 +64,15 @@ class AbstractServiceTest extends JUnitSuite {
   }
 
   @Test
+  def testListIsFavourite() : Unit = {
+    var abstracts = srv.listIsFavourite(assets.conferences(0), assets.alice)
+    assert(abstracts.size == 0)
+
+    abstracts = srv.listIsFavourite(assets.conferences(0), assets.bob)
+    assert(abstracts.size == assets.abstracts.size)
+  }
+
+  @Test
   def testGet() : Unit = {
     val abstr = srv.get(assets.abstracts(0).uuid)
     assert(abstr.uuid == assets.abstracts(0).uuid)


### PR DESCRIPTION
With this pull request 

- stars will be shown in the conference abstract list, indicating favourite abstracts of an user. Closes issue #419.
- the favour/disfavour abstract methods in abstract-list.js will only use javascript.
- the string length of notes when changing abstract states will be limited to 255 to avoid database problems. Closes issue #448.