### PR TITLE
Favourite Abstracts Tests

### DIFF
--- a/app/controllers/api/Abstracts.scala
+++ b/app/controllers/api/Abstracts.scala
@@ -272,7 +272,7 @@ extends Silhouette[Login, CachedCookieAuthenticator] {
     *
     * @return The id of the updated Abstract as JSON
     */
-  def addFavUser(id: String) = SecuredAction(parse.json) { implicit request =>
+  def addFavUser(id: String) = SecuredAction { implicit request =>
     val abstr = abstractService.get(id)
     abstractService.addFavUser(abstr, request.identity.account)
     Ok(Json.toJson(id))

--- a/app/controllers/api/Abstracts.scala
+++ b/app/controllers/api/Abstracts.scala
@@ -282,7 +282,7 @@ extends Silhouette[Login, CachedCookieAuthenticator] {
     *
     * @return The id of the updated Abstract as JSON
     */
-  def removeFavUser(id: String) = SecuredAction(parse.json) { implicit request =>
+  def removeFavUser(id: String) = SecuredAction { implicit request =>
     val abstr = abstractService.get(id)
     abstractService.removeFavUser(abstr, request.identity.account)
     Ok(Json.toJson(id))

--- a/app/service/AbstractService.scala
+++ b/app/service/AbstractService.scala
@@ -187,20 +187,6 @@ class AbstractService(figPath: String) extends PermissionsBase {
     }
   }
 
-  def isFavourite(conference: Conference, account: Account) : Seq[Abstract] = {
-    query { em =>
-      val queryStr =
-        """SELECT DISTINCT a FROM Abstract a
-           LEFT JOIN FETCH a.favUsers f
-           WHERE a.uuid = :AbstrUuid AND f.uuid = :FavUserUuid
-           ORDER BY a.sortId, a.title"""
-      val query: TypedQuery[Abstract] = em.createQuery(queryStr, classOf[Abstract])
-      query.setParameter("ConfUuid", conference.uuid)
-      query.setParameter("FavUserUuid", account.uuid)
-      asScalaBuffer(query.getResultList)
-    }
-  }
-
   /**
    * Return a published (= Accepted && Conference.isPublished) abstract by id.
    *

--- a/app/service/AbstractService.scala
+++ b/app/service/AbstractService.scala
@@ -435,6 +435,17 @@ class AbstractService(figPath: String) extends PermissionsBase {
     */
   def addFavUser(abstr : Abstract, account: Account) : Abstract = {
     val abstrUpdated = transaction { (em, tx) =>
+      if (abstr.uuid == null)
+        throw new IllegalArgumentException("Unable to update an abstract with null uuid")
+
+      val abstrChecked = em.find(classOf[Abstract], abstr.uuid)
+      if (abstrChecked == null)
+        throw new EntityNotFoundException("Unable to find abstract with uuid = " + abstr.uuid)
+
+      val accountChecked = em.find(classOf[Account], account.uuid)
+      if (accountChecked == null)
+        throw new EntityNotFoundException("Unable to find account with uuid = " + account.uuid)
+
       abstr.favUsers.add(account)
       val merged = em.merge(abstr)
       merged

--- a/app/service/AbstractService.scala
+++ b/app/service/AbstractService.scala
@@ -462,6 +462,18 @@ class AbstractService(figPath: String) extends PermissionsBase {
     */
   def removeFavUser(abstr : Abstract, account: Account) : Abstract = {
     val abstrUpdated = transaction { (em, tx) =>
+
+      if (abstr.uuid == null)
+        throw new IllegalArgumentException("Unable to update an abstract with null uuid")
+
+      val abstrChecked = em.find(classOf[Abstract], abstr.uuid)
+      if (abstrChecked == null)
+        throw new EntityNotFoundException("Unable to find abstract with uuid = " + abstr.uuid)
+
+      val accountChecked = em.find(classOf[Account], account.uuid)
+      if (accountChecked == null)
+        throw new EntityNotFoundException("Unable to find account with uuid = " + account.uuid)
+
       abstr.favUsers.remove(account)
       val merged = em.merge(abstr)
       merged

--- a/test/controller/AbstractsCtrlTest.scala
+++ b/test/controller/AbstractsCtrlTest.scala
@@ -198,6 +198,33 @@ class AbstractsCtrlTest extends BaseCtrlTest {
   }
 
   @Test
+  def testListFavByConf() {
+
+    val cid = assets.conferences(0).uuid
+    val reqNoAuth = FakeRequest(GET, s"/api/user/self/conferences/$cid/favouriteabstracts")
+
+    val reqNoAuthResult = routeWithErrors(AbstractsCtrlTest.app, reqNoAuth).get
+    assert(status(reqNoAuthResult) == UNAUTHORIZED)
+
+    val reqAuth = reqNoAuth.withCookies(cookie)
+    val reqAuthResult = route(AbstractsCtrlTest.app, reqAuth).get
+    assert(status(reqAuthResult) == OK)
+    assert(header(ETAG, reqAuthResult).isDefined)
+
+    val loadedAbsAlice = contentAsJson(reqAuthResult).as[Seq[Abstract]]
+
+    assert(loadedAbsAlice.isEmpty)
+
+    val bobCookie = getCookie(assets.bob, "testtest")
+    val reqBob = reqNoAuth.withCookies(bobCookie)
+    val reqBobResult = route(AbstractsCtrlTest.app, reqBob).get
+    assert(status(reqBobResult) == OK)
+
+    val loadedAbs = contentAsJson(reqBobResult).as[Seq[Abstract]]
+    assert(loadedAbs.length == assets.abstracts.size)
+  }
+
+  @Test
   def testListFavUuidByConf() {
 
     val cid = assets.conferences(0).uuid

--- a/test/controller/AbstractsCtrlTest.scala
+++ b/test/controller/AbstractsCtrlTest.scala
@@ -271,6 +271,27 @@ class AbstractsCtrlTest extends BaseCtrlTest {
   }
 
   @Test
+  def testDeleteFavUser() {
+    //Add
+    val absUUID = assets.abstracts(0).uuid
+    val reqNoAuth = FakeRequest(DELETE, s"/api/abstracts/$absUUID/removefavuser")
+    val reqNoAuthResult = route(AbstractsCtrlTest.app, reqNoAuth).get
+    assert(status(reqNoAuthResult) == UNAUTHORIZED)
+
+    val reqAuth = reqNoAuth.withCookies(cookie)
+
+    val reqAuthResult = route(AbstractsCtrlTest.app, reqAuth).get
+    assert(status(reqAuthResult) == OK)
+
+    val cid = assets.conferences(0).uuid
+    val reqList = FakeRequest(GET, s"/api/user/self/conferences/$cid/favabstractuuids").withCookies(cookie)
+
+    val reqListResult = route(AbstractsCtrlTest.app, reqList).get
+    val loadedJSONAlice = contentAsJson(reqListResult).as[Array[String]]
+    assert(loadedJSONAlice.length == 0)
+  }
+
+  @Test
   def testDelete() {
     val absUUID = assets.abstracts(0).uuid
     val reqNoAuth = FakeRequest(DELETE, s"/api/abstracts/$absUUID")

--- a/test/controller/AbstractsCtrlTest.scala
+++ b/test/controller/AbstractsCtrlTest.scala
@@ -156,6 +156,24 @@ class AbstractsCtrlTest extends BaseCtrlTest {
   }
 
   @Test
+  def testListFavByAccount() {
+
+    val bobCookie = getCookie(assets.bob, "testtest")
+    val uid = assets.bob.uuid
+    val reqNoAuth = FakeRequest(GET, s"/api/user/$uid/favouriteabstracts")
+    val reqNoAuthResult = route(AbstractsCtrlTest.app, reqNoAuth).get
+    assert(status(reqNoAuthResult) == UNAUTHORIZED)
+
+    val reqAuth = reqNoAuth.withCookies(bobCookie)
+
+    val reqAuthResult = route(AbstractsCtrlTest.app, reqAuth).get
+    assert(status(reqAuthResult) == OK)
+
+    val loadedAbs = contentAsJson(reqAuthResult).as[Seq[Abstract]]
+    assert(loadedAbs.nonEmpty)
+  }
+
+  @Test
   def testListByConference() {
 
     val cid = assets.conferences(0).uuid

--- a/test/controller/AbstractsCtrlTest.scala
+++ b/test/controller/AbstractsCtrlTest.scala
@@ -250,6 +250,27 @@ class AbstractsCtrlTest extends BaseCtrlTest {
   }
 
   @Test
+  def testAddFavUser() {
+    //Add
+    val absUUID = assets.abstracts(0).uuid
+    val reqNoAuth = FakeRequest(PUT, s"/api/abstracts/$absUUID/addfavuser")
+    val reqNoAuthResult = route(AbstractsCtrlTest.app, reqNoAuth).get
+    assert(status(reqNoAuthResult) == UNAUTHORIZED)
+
+    val reqAuth = reqNoAuth.withCookies(cookie)
+
+    val reqAuthResult = route(AbstractsCtrlTest.app, reqAuth).get
+    assert(status(reqAuthResult) == OK)
+
+    val cid = assets.conferences(0).uuid
+    val reqList = FakeRequest(GET, s"/api/user/self/conferences/$cid/favabstractuuids").withCookies(cookie)
+
+    val reqListResult = route(AbstractsCtrlTest.app, reqList).get
+    val loadedJSONAlice = contentAsJson(reqListResult).as[Array[String]]
+    assert(loadedJSONAlice.length > 0)
+  }
+
+  @Test
   def testDelete() {
     val absUUID = assets.abstracts(0).uuid
     val reqNoAuth = FakeRequest(DELETE, s"/api/abstracts/$absUUID")

--- a/test/service/AbstractServiceTest.scala
+++ b/test/service/AbstractServiceTest.scala
@@ -195,6 +195,23 @@ class AbstractServiceTest extends JUnitSuite {
   }
 
   @Test
+  def testAddFavUSer() : Unit = {
+    val abstr = assets.abstracts(0)
+    srv.addFavUser(abstr, assets.alice)
+    assert(abstr.favUsers.contains(assets.alice))
+
+    val illegal = assets.createAbstract()
+    illegal.uuid = "wrongid"
+    intercept[EntityNotFoundException] {
+      srv.addFavUser(illegal, assets.alice)
+    }
+
+    intercept[EntityNotFoundException] {
+      srv.addFavUser(abstr, Account(Some("uuid"), Some("foo@bar.com")))
+    }
+  }
+
+  @Test
   def testDelete() : Unit = {
     val original = assets.abstracts(0)
 

--- a/test/service/AbstractServiceTest.scala
+++ b/test/service/AbstractServiceTest.scala
@@ -64,6 +64,15 @@ class AbstractServiceTest extends JUnitSuite {
   }
 
   @Test
+  def testListFavourite() : Unit = {
+    var abstracts = srv.listFavourite(assets.alice)
+    assert(abstracts.isEmpty)
+
+    abstracts = srv.listFavourite(assets.bob)
+    assert(abstracts.length == assets.abstracts.length)
+  }
+
+  @Test
   def testListIsFavourite() : Unit = {
     var abstracts = srv.listIsFavourite(assets.conferences(0), assets.alice)
     assert(abstracts.size == 0)

--- a/test/service/AbstractServiceTest.scala
+++ b/test/service/AbstractServiceTest.scala
@@ -114,6 +114,22 @@ class AbstractServiceTest extends JUnitSuite {
   }
 
   @Test
+  def testGetFav() : Unit = {
+    srv.getFav(assets.abstracts(0).uuid, assets.bob)
+
+    intercept[EntityNotFoundException] {
+      srv.getFav(
+        assets.abstracts(0).uuid,
+        Account(Some("uuid"), Some("not@valid.com"))
+      )
+    }
+
+    intercept[NoResultException] {
+      srv.getFav("NONEXISTENT", assets.eve)
+    }
+  }
+
+  @Test
   def testCreate() : Unit = {
     val original = assets.createAbstract()
     val abstr = srv.create(original, assets.conferences(0), assets.alice)

--- a/test/service/AbstractServiceTest.scala
+++ b/test/service/AbstractServiceTest.scala
@@ -212,6 +212,24 @@ class AbstractServiceTest extends JUnitSuite {
   }
 
   @Test
+  def testRemoveFavUSer() : Unit = {
+    val abstr = assets.abstracts(0)
+    srv.addFavUser(abstr, assets.alice)
+    srv.removeFavUser(abstr, assets.alice)
+    assert(!abstr.favUsers.contains(assets.alice))
+
+    val illegal = assets.createAbstract()
+    illegal.uuid = "wrongid"
+    intercept[EntityNotFoundException] {
+      srv.removeFavUser(illegal, assets.alice)
+    }
+
+    intercept[EntityNotFoundException] {
+      srv.removeFavUser(abstr, Account(Some("uuid"), Some("foo@bar.com")))
+    }
+  }
+
+  @Test
   def testDelete() : Unit = {
     val original = assets.abstracts(0)
 


### PR DESCRIPTION
This pull request adds tests for functions in Abstracts controller und AbstractService used for the favourite abstracts functionality as well as some minor changes to these functions, not changing the funtionality of them. The isFavourite routine is deleted, as it was replaced.