### PR TITLE
Minor banner upload fixes

### DIFF
--- a/app/assets/javascripts/conference-list.js
+++ b/app/assets/javascripts/conference-list.js
@@ -66,13 +66,14 @@ require(["main"], function () {
                                     if (banFound === false) {
                                         self.logos.push("");
                                     }
-                                } else if (conf.isPublished) {
+                                } else {
                                     for (i = 0; i < conf.banner.length; i++) {
-                                        if (conf.banner[i].bType === "thumbnail") {
+                                        if (conf.isPublished && conf.banner[i].bType === "thumbnail") {
                                             self.thumbnails.push(conf.banner[i]);
                                             banFound = true;
                                         }
                                     }
+                                    // Include published and unpublished conferences to not mess up the index
                                     if (banFound === false) {
                                         self.thumbnails.push("");
                                     }

--- a/app/controllers/api/Banners.scala
+++ b/app/controllers/api/Banners.scala
@@ -34,7 +34,7 @@ class Banners(implicit val env: Environment[Login, CachedCookieAuthenticator])
     * @return  OK / Failed
     */
   def upload(id: String) = SecuredAction(parse.multipartFormData) { implicit request =>
-    val conference = conferenceService.getOwn(id, request.identity.account)
+    val conference = conferenceService.get(id)
     val tempfile = request.body.file("file").map {
       banner => banner.ref
     }.getOrElse {


### PR DESCRIPTION
This PR introduces two minor banner upload fixes and closes #385:
- now both conference and site admin are able to upload banners via the conference administration.
- fixes the small issue that conference thumbnails on the main conference listing page were incorrectly shifted to another conference, if a non-active, non-published conference was in the conference list.
