### PR TITLE
Hotfix Maven project build issue

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,6 +7,8 @@ lazy val `GCA-Web`: Project = (project in file(".")).enablePlugins(PlayScala)
 
 scalaVersion := "2.11.1"
 
+resolvers += "new maven" at "https://repo1.maven.org/maven2/"
+
 libraryDependencies ++= Seq(
   jdbc,
   anorm,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,9 @@
 // Comment to get more information during initialization
 logLevel := Level.Warn
 
-// The Typesafe repository
-resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
+// Typesafe repository and required updated maven repository
+resolvers ++= Seq("Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/",
+                  "new maven" at "https://repo1.maven.org/maven2/")
 
 // The Play plugin
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.3.10")


### PR DESCRIPTION
This PR is a hotfix for issue #497.

The build time is dramatically increased since the build tool still tries to fetch all dependencies from the `http` maven repository first and fails before moving on to the additionally provided functional URL.