### PR TITLE
Conference Creation Tests

### DIFF
--- a/app/views/conferencelist.scala.html
+++ b/app/views/conferencelist.scala.html
@@ -99,9 +99,12 @@
         }
 
         @if(account.isDefined) {
+            <hr>
+                <h3>Unpublished conferences</h3>
+            <br/>
             @for((conference,i) <- list_other.zipWithIndex) {
                 @if(!conference.isPublished && (conference.isOwner(account.get) || account.get.isAdmin)) {
-                    <div class="media">
+                    <div class="media unpublished">
                         <div class="pull-left media-left">
                             <a href="@routes.Application.conference(conference.short)"
                             data-bind="ifnot: $root.thumbnails()[@i]">
@@ -119,7 +122,6 @@
 
                         </div>
                         <div class="media-body">
-                            <h4 class="alert-danger">Unpublished</h4>
                             <h4 id="@conference.short" class="media-heading">@conference.name</h4>
                             <p>@conference.formatDuration</p>
                             <div class="form-group">

--- a/app/views/conferencelist.scala.html
+++ b/app/views/conferencelist.scala.html
@@ -97,5 +97,42 @@
             </div>
             }
         }
+
+        @if(account.isDefined) {
+            @for((conference,i) <- list_other.zipWithIndex) {
+                @if(!conference.isPublished && (conference.isOwner(account.get) || account.get.isAdmin)) {
+                    <div class="media">
+                        <div class="pull-left media-left">
+                            <a href="@routes.Application.conference(conference.short)"
+                            data-bind="ifnot: $root.thumbnails()[@i]">
+                            @if(conference.getConfText("thumbnail") != null
+                                    && conference.getConfText("thumbnail") != "") {
+                                <img class="conference-logo img-responsive img-rounded"
+                                src='@conference.getConfText("thumbnail")'>
+                                }
+                            </a>
+                            <a href="@routes.Application.conference(conference.short)"
+                            data-bind="if: $root.thumbnails()[@i]">
+                                <img class="media-object conference-thumbnail" src=""
+                                data-bind="attr: {src: $root.thumbnails()[@i].URL}">
+                            </a>
+
+                        </div>
+                        <div class="media-body">
+                            <h4 class="alert-danger">Unpublished</h4>
+                            <a href="@routes.Application.abstractsPublic(conference.short)">
+                                <h4 class="media-heading">@conference.name</h4>
+                            </a>
+                            <p>@conference.formatDuration</p>
+                            <div class="form-group">
+                                <a href="@routes.Application.adminConference(conference.uuid)" class="btn btn-danger">
+                                    Conference Settings
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+                }
+            }
+        }
     }
 }

--- a/app/views/conferencelist.scala.html
+++ b/app/views/conferencelist.scala.html
@@ -120,9 +120,7 @@
                         </div>
                         <div class="media-body">
                             <h4 class="alert-danger">Unpublished</h4>
-                            <a href="@routes.Application.abstractsPublic(conference.short)">
-                                <h4 class="media-heading">@conference.name</h4>
-                            </a>
+                            <h4 id="@conference.short" class="media-heading">@conference.name</h4>
                             <p>@conference.formatDuration</p>
                             <div class="form-group">
                                 <a href="@routes.Application.adminConference(conference.uuid)" class="btn btn-danger">

--- a/app/views/dashboard/admin/conference.scala.html
+++ b/app/views/dashboard/admin/conference.scala.html
@@ -271,7 +271,9 @@
                     <div class="col-sm-2 text-right"><b>Topics</b></div>
                     <ul class="col-sm-10 list-inline" data-bind="sortable: topics">
                         <li><span class="label label-default" data-bind="text: $data"></span>
-                            <a data-bind="click: $root.removeTopic"><span class="glyphicon glyphicon-remove"></span></a>
+                            <a class="btn-remove-topic" data-bind="click: $root.removeTopic">
+                                <span class="glyphicon glyphicon-remove"></span>
+                            </a>
                         </li>
                     </ul>
                 </div>
@@ -282,7 +284,7 @@
                                 maxlength='@Model.getLimit[Topic]("topic")'>
                     </div>
                     <div class="col-sm-1">
-                        <a class="btn btn-default" data-bind="click: $root.addTopic">
+                        <a id="btn-add-topic" class="btn btn-default" data-bind="click: $root.addTopic">
                             <span class="glyphicon glyphicon-plus"></span> Add Topic</a>
                     </div>
                 </div>

--- a/test/frontend/Cookies.py
+++ b/test/frontend/Cookies.py
@@ -42,6 +42,15 @@ def set_cookies(driver, user, password):
     save_cookies(driver, cookies_location)
 
 
+def admin_login(driver, user="alice@foo.com", password="testtest"):
+
+    driver.get("http://" + get_host_ip() + ":9000/login")
+    driver.maximize_window()
+    driver.find_element_by_id("identifier").send_keys(user)
+    driver.find_element_by_id("password").send_keys(password)
+    driver.find_element_by_id("submit").click()
+
+
 def get_host_ip():
     try:
         host_name = socket.gethostname()

--- a/test/frontend/Readme.md
+++ b/test/frontend/Readme.md
@@ -130,6 +130,23 @@ Compare with the already used set up functions in the conftest.py file.
 An issue with selenium is that using `localhost` in URLs can cause problems with, e.g. loading cookies.
 As a workaround, always use the `Cookies.get_host_ip()`.
 
+With most browser drivers, elements searched for by functions of the type ```driver.get_element_by_*()```, will be 
+found automatically, even if they're outside of the section currently viewed on the screen. In Firefox resp. with 
+Gecko driver, an error will be returned in such cases. It is important for Firefox to always navigate/scroll to the
+element before examination by using ```move_to_element_by_*()```. For often used actions like ```click()```, 
+```send_keys()``` or ```get_attribute()``` functions including this are predefined in the conftest.py
+file.
+
+Generally tests run stable. In some incidences a test might fail due to local issues, repeating the test might work 
+then. To avoid such problems, it is useful to include
+```python
+WebDriverWait(driver, 30).until(
+    # insert expected condition, e.g.
+    EC.presence_of_element_located((By.XPATH, ''))
+)
+```
+after processes that are expected to need some time to execute, e.g. when saving a form or loading a page or modal.
+
 For all things python and selenium, it's good to have a look at this page:  
 https://selenium-python.readthedocs.io/
 

--- a/test/frontend/conftest.py
+++ b/test/frontend/conftest.py
@@ -53,6 +53,24 @@ def element_click_by_xpath(driver, xpath):
     driver.find_element_by_xpath(xpath).click()
 
 
+def element_send_keys_by_id(driver, name, keys):
+    move_to_element_by_id(driver, name)
+    driver.find_element_by_id(name).clear()
+    driver.find_element_by_id(name).send_keys(keys)
+
+
+def element_send_keys_by_class_name(driver, name, keys):
+    move_to_element_by_class_name(driver, name)
+    driver.find_element_by_class_name(name).clear()
+    driver.find_element_by_class_name(name).send_keys(keys)
+
+
+def element_send_keys_by_xpath(driver, xpath, keys):
+    move_to_element_by_xpath(driver, xpath)
+    driver.find_element_by_xpath(xpath).clear()
+    driver.find_element_by_xpath(xpath).send_keys(keys)
+
+
 def maximize_login(request):
     if request.param == "chrome":
         driver = webdriver.Remote(

--- a/test/frontend/conftest.py
+++ b/test/frontend/conftest.py
@@ -17,8 +17,22 @@ def scroll(driver, object):
         driver.execute_script(scroll_by_coord)
 
 
+def move_to_element_by_id(driver, name):
+    element = driver.find_element_by_id(name)
+    scroll(driver, element)
+    hover = ActionChains(driver).move_to_element(element)
+    hover.perform()
+
+
 def move_to_element_by_class_name(driver, name):
     element = driver.find_element_by_class_name(name)
+    scroll(driver, element)
+    hover = ActionChains(driver).move_to_element(element)
+    hover.perform()
+
+
+def move_to_element_by_xpath(driver, xpath):
+    element = driver.find_element_by_xpath(xpath)
     scroll(driver, element)
     hover = ActionChains(driver).move_to_element(element)
     hover.perform()

--- a/test/frontend/conftest.py
+++ b/test/frontend/conftest.py
@@ -38,6 +38,21 @@ def move_to_element_by_xpath(driver, xpath):
     hover.perform()
 
 
+def element_click_by_id(driver, name):
+    move_to_element_by_id(driver, name)
+    driver.find_element_by_id(name).click()
+
+
+def element_click_by_class_name(driver, name):
+    move_to_element_by_class_name(driver, name)
+    driver.find_element_by_class_name(name).click()
+
+
+def element_click_by_xpath(driver, xpath):
+    move_to_element_by_xpath(driver, xpath)
+    driver.find_element_by_xpath(xpath).click()
+
+
 def maximize_login(request):
     if request.param == "chrome":
         driver = webdriver.Remote(

--- a/test/frontend/conftest.py
+++ b/test/frontend/conftest.py
@@ -128,3 +128,16 @@ def setup_editor(request):
     )
     yield
     driver.quit()
+
+
+@pytest.fixture(params=["chrome", "firefox"], scope="session")
+def setup_conference_creation(request):
+
+    driver = maximize_login(request)
+    Cookies.load_cookies(driver)
+    driver.get("http://" + Cookies.get_host_ip() + ":9000/dashboard/conference")
+    WebDriverWait(driver, 30).until(
+        EC.presence_of_element_located((By.CLASS_NAME, 'btn-success'))
+    )
+    yield
+    driver.quit()

--- a/test/frontend/conftest.py
+++ b/test/frontend/conftest.py
@@ -71,6 +71,21 @@ def element_send_keys_by_xpath(driver, xpath, keys):
     driver.find_element_by_xpath(xpath).send_keys(keys)
 
 
+def element_get_attribute_by_id(driver, name, attr):
+    move_to_element_by_id(driver, name)
+    return driver.find_element_by_id(name).get_attribute(attr)
+
+
+def element_get_attribute_by_class_name(driver, name, attr):
+    move_to_element_by_class_name(driver, name)
+    return driver.find_element_by_class_name(name).get_attribute(attr)
+
+
+def element_get_attribute_by_xpath(driver, xpath, attr):
+    move_to_element_by_xpath(driver, xpath)
+    return driver.find_element_by_xpath(xpath).get_attribute(attr)
+
+
 def maximize_login(request):
     if request.param == "chrome":
         driver = webdriver.Remote(

--- a/test/frontend/conftest.py
+++ b/test/frontend/conftest.py
@@ -121,7 +121,7 @@ def setup_login(request):
 def setup_editor(request):
 
     driver = maximize_login(request)
-    Cookies.load_cookies(driver)
+    Cookies.admin_login(driver)
     driver.get("http://" + Cookies.get_host_ip() + ":9000/conference/BC14/submission")
     WebDriverWait(driver, 30).until(
         EC.presence_of_element_located((By.CLASS_NAME, 'btn-success'))
@@ -134,7 +134,7 @@ def setup_editor(request):
 def setup_conference_creation(request):
 
     driver = maximize_login(request)
-    Cookies.load_cookies(driver)
+    Cookies.admin_login(driver=driver)
     driver.get("http://" + Cookies.get_host_ip() + ":9000/dashboard/conference")
     WebDriverWait(driver, 30).until(
         EC.presence_of_element_located((By.CLASS_NAME, 'btn-success'))

--- a/test/frontend/load_cookies.py
+++ b/test/frontend/load_cookies.py
@@ -1,6 +1,0 @@
-from selenium import webdriver
-import Cookies
-
-driver = webdriver.Chrome()
-Cookies.set_cookies(driver, "alice@foo.com", "testtest")
-driver.quit()

--- a/test/frontend/test_conference_creation.py
+++ b/test/frontend/test_conference_creation.py
@@ -66,3 +66,12 @@ class TestConferenceCreation:
             EC.presence_of_element_located((By.ID, 'active'))
         )
         element_click_by_id(driver, 'active')
+
+    def test_submission(self):
+        driver = self.driver
+        WebDriverWait(driver, 30).until(
+            EC.presence_of_element_located((By.ID, 'submission'))
+        )
+        element_click_by_id(driver, 'submission')
+
+        element_click_by_class_name(driver, 'btn-success')

--- a/test/frontend/test_conference_creation.py
+++ b/test/frontend/test_conference_creation.py
@@ -216,3 +216,10 @@ class TestConferenceCreation:
             EC.presence_of_element_located((By.ID, 'notice'))
         )
         element_send_keys_by_id(driver, 'notice', 'Check abstracts before submission!')
+
+    def test_presentation_preferences(self):
+        driver = self.driver
+        WebDriverWait(driver, 30).until(
+            EC.presence_of_element_located((By.ID, 'presentation'))
+        )
+        element_click_by_id(driver, 'presentation')

--- a/test/frontend/test_conference_creation.py
+++ b/test/frontend/test_conference_creation.py
@@ -198,3 +198,7 @@ class TestConferenceCreation:
             EC.presence_of_element_located((By.ID, 'iosapp'))
         )
         element_send_keys_by_id(driver, 'iosapp', '999999999')
+
+    def test_link(self):
+        driver = self.driver
+        element_send_keys_by_id(driver, 'link', 'http://www.nncn.de/en/bernstein-conference/2014')

--- a/test/frontend/test_conference_creation.py
+++ b/test/frontend/test_conference_creation.py
@@ -120,12 +120,33 @@ class TestConferenceCreation:
 
     def test_submission(self):
         driver = self.driver
+
+        WebDriverWait(driver, 30).until(
+            EC.presence_of_element_located((By.ID, 'short'))
+        )
+        tc_num = element_get_attribute_by_id(driver, 'short', 'value')
+
+        driver.get("http://" + Cookies.get_host_ip() + ":9000/conference/" + tc_num)
+        assert len(driver.find_elements_by_xpath('//ul[contains(@class,"nav")]'
+                                                 '//li/a[contains(text(),"Submission")]')) == 0
+        assert len(driver.find_elements_by_xpath('//div[@class="jumbotron"]//a[contains(text(),"Submit")]')) == 0
+
+        element_click_by_xpath(driver, '//div[@class="jumbotron"]//a[contains(text(),"Conference Settings")]')
+
         WebDriverWait(driver, 30).until(
             EC.presence_of_element_located((By.ID, 'submission'))
         )
         element_click_by_id(driver, 'submission')
 
         element_click_by_class_name(driver, 'btn-success')
+
+        driver.get("http://" + Cookies.get_host_ip() + ":9000/conference/" + tc_num)
+
+        assert len(driver.find_elements_by_xpath('//ul[contains(@class,"nav")]'
+                                                 '//li/a[contains(text(),"Submission")]')) == 1
+        assert len(driver.find_elements_by_xpath('//div[@class="jumbotron"]//a[contains(text(),"Submit")]')) == 1
+
+        element_click_by_xpath(driver, '//div[@class="jumbotron"]//a[contains(text(),"Conference Settings")]')
 
     def test_group(self):
         driver = self.driver

--- a/test/frontend/test_conference_creation.py
+++ b/test/frontend/test_conference_creation.py
@@ -464,6 +464,27 @@ class TestConferenceCreation:
         move_to_element_by_id(driver, 'mAbsLen')
         assert "300" == driver.find_element_by_id('mAbsLen').get_attribute('value')
 
+        tc_num = element_get_attribute_by_id(driver, 'short', 'value')
+
+        driver.get("http://" + Cookies.get_host_ip() + ":9000/conference/" + tc_num + "/submission")
+
+        move_to_element_by_class_name(driver, 'abstract-text')
+        WebDriverWait(driver, 10).until(
+            EC.visibility_of_element_located((By.ID, 'button-edit-abstract-text'))
+        )
+        driver.find_element_by_id('button-edit-abstract-text').click()
+
+        WebDriverWait(driver, 30).until(
+            EC.visibility_of_element_located((By.XPATH, '//*[@id="abstract-text-editor"]'))
+        )
+
+        assert driver.find_element_by_xpath('//*[@id="abstract-text-editor"]'
+                                            '//textarea[@id="text"]').get_attribute("maxlength") == '300'
+        driver.find_element(By.XPATH, '//*[@id="abstract-text-editor"]//button[@id="modal-button-ok"]').click()
+
+        driver.get("http://" + Cookies.get_host_ip() + ":9000/conference/" + tc_num)
+        element_click_by_xpath(driver, '//div[@class="jumbotron"]//a[contains(text(),"Conference Settings")]')
+
     def test_maximum_figures(self):
         driver = self.driver
         WebDriverWait(driver, 30).until(

--- a/test/frontend/test_conference_creation.py
+++ b/test/frontend/test_conference_creation.py
@@ -41,3 +41,10 @@ class TestConferenceCreation:
             EC.invisibility_of_element_located((By.XPATH, '//div[contains(@class,"alert-danger")]/strong'))
         )
         assert len(driver.find_elements_by_xpath('//div[contains(@class,"alert-danger")]/strong')) == 0
+
+    def test_published(self):
+        driver = self.driver
+        WebDriverWait(driver, 30).until(
+            EC.presence_of_element_located((By.ID, 'published'))
+        )
+        element_click_by_id(driver, 'published')

--- a/test/frontend/test_conference_creation.py
+++ b/test/frontend/test_conference_creation.py
@@ -270,3 +270,18 @@ class TestConferenceCreation:
         )
         move_to_element_by_id(driver, 'mAbsLen')
         assert "300" == driver.find_element_by_id('mAbsLen').get_attribute('value')
+
+    def test_maximum_figures(self):
+        driver = self.driver
+        WebDriverWait(driver, 30).until(
+            EC.presence_of_element_located((By.ID, 'mFigs'))
+        )
+        element_send_keys_by_id(driver, 'mFigs', '3')
+
+        element_click_by_class_name(driver, 'btn-success')
+
+        WebDriverWait(driver, 30).until(
+            EC.presence_of_element_located((By.ID, 'mFigs'))
+        )
+        move_to_element_by_id(driver, 'mFigs')
+        assert "3" == driver.find_element_by_id('mFigs').get_attribute('value')

--- a/test/frontend/test_conference_creation.py
+++ b/test/frontend/test_conference_creation.py
@@ -1,0 +1,21 @@
+import pytest
+import Cookies
+from uuid import uuid1
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
+from conftest import *
+
+
+@pytest.mark.usefixtures("setup_conference_creation")
+class TestConferenceCreation:
+
+    def test_name(self):
+        driver = self.driver
+        element_send_keys_by_id(driver, 'name', "Test Conference")
+        element_click_by_class_name(driver, 'btn-success')
+
+        #test automatic fill-in
+        assert "TC" in element_get_attribute_by_id(driver, 'short', 'value')
+        assert "500" == element_get_attribute_by_id(driver, 'mAbsLen', 'value')
+        assert "0" == element_get_attribute_by_id(driver, 'mFigs', 'value')

--- a/test/frontend/test_conference_creation.py
+++ b/test/frontend/test_conference_creation.py
@@ -103,6 +103,21 @@ class TestConferenceCreation:
         )
         element_click_by_id(driver, 'active')
 
+        tc_num = element_get_attribute_by_id(driver, 'short', 'value')
+        element_click_by_class_name(driver, 'btn-success')
+
+        driver.get("http://" + Cookies.get_host_ip() + ":9000/")
+
+        assert len(driver.find_elements_by_xpath('//div[@class="jumbotron"]/h3'
+                                                 '/a[contains(@href,"' + tc_num + '")]')) == 1
+
+        move_to_element_by_xpath(driver, '//div[@class="jumbotron"]/h3/a[contains(@href,"' + tc_num + '")]')
+        conf_div = driver.find_element_by_xpath('//div[@class="jumbotron"]/h3/a[contains(@href,"' + tc_num + '")]/../..')
+        assert len(conf_div.find_elements_by_xpath('.//a[contains(text(),"Manage")]')) == 1
+        assert len(conf_div.find_elements_by_xpath('.//a[contains(text(),"Conference Settings")]')) == 1
+
+        conf_div.find_element_by_xpath('.//a[contains(text(),"Conference Settings")]').click()
+
     def test_submission(self):
         driver = self.driver
         WebDriverWait(driver, 30).until(

--- a/test/frontend/test_conference_creation.py
+++ b/test/frontend/test_conference_creation.py
@@ -499,3 +499,26 @@ class TestConferenceCreation:
         )
         move_to_element_by_id(driver, 'mFigs')
         assert "3" == driver.find_element_by_id('mFigs').get_attribute('value')
+
+        tc_num = element_get_attribute_by_id(driver, 'short', 'value')
+        driver.get("http://" + Cookies.get_host_ip() + ":9000/conference/" + tc_num + "/submission")
+
+        move_to_element_by_class_name(driver, 'figure')
+        assert len(driver.find_elements_by_class_name('figure')) == 1
+
+        WebDriverWait(driver, 10).until(
+            EC.visibility_of_element_located((By.ID, 'button-edit-figure'))
+        )
+        driver.find_element_by_id('button-edit-figure').click()
+
+        WebDriverWait(driver, 10).until(
+            EC.element_to_be_clickable((By.XPATH, '//*[@id="figures-editor"]'))
+        )
+
+        assert len(driver.find_elements_by_xpath('//*[@id="figures-editor"]//div[@class="modal-body"]'
+                                                 '//div[contains(@data-bind, "figures().length>=3")]')) == 1
+
+        driver.find_element_by_xpath('//*[@id="figures-editor"]//button[@id="modal-button-ok"]').click()
+
+        driver.get("http://" + Cookies.get_host_ip() + ":9000/conference/" + tc_num)
+        element_click_by_xpath(driver, '//div[@class="jumbotron"]//a[contains(text(),"Conference Settings")]')

--- a/test/frontend/test_conference_creation.py
+++ b/test/frontend/test_conference_creation.py
@@ -359,6 +359,16 @@ class TestConferenceCreation:
         )
         element_click_by_id(driver, 'presentation')
 
+        tc_num = element_get_attribute_by_id(driver, 'short', 'value')
+        element_click_by_class_name(driver, 'btn-success')
+
+        driver.get("http://" + Cookies.get_host_ip() + ":9000/conference/" + tc_num + "/submission")
+
+        assert len(driver.find_elements_by_class_name('poster-or-talk')) == 1
+
+        driver.get("http://" + Cookies.get_host_ip() + ":9000/conference/" + tc_num)
+        element_click_by_xpath(driver, '//div[@class="jumbotron"]//a[contains(text(),"Conference Settings")]')
+
     def test_add_topic(self):
         driver = self.driver
         WebDriverWait(driver, 30).until(

--- a/test/frontend/test_conference_creation.py
+++ b/test/frontend/test_conference_creation.py
@@ -88,3 +88,36 @@ class TestConferenceCreation:
         element_send_keys_by_id(driver, 'cite', 'The Test Conf, Somewhere, Sometime')
 
         element_click_by_class_name(driver, 'btn-success')
+
+    def test_start_date(self):
+        driver = self.driver
+        WebDriverWait(driver, 30).until(
+            EC.presence_of_element_located((By.ID, 'start'))
+        )
+        element_click_by_id(driver, 'start')
+
+        move_to_element_by_id(driver, 'ui-datepicker-div')
+        driver.find_element_by_xpath('//a[contains(@class,"ui-datepicker-next")]').click()
+        driver.find_element_by_xpath('//div[@id="ui-datepicker-div"]//a[contains(text(), "14")]').click()
+        driver.find_element_by_xpath('//button[contains(@class, "datepicker-close")]').click()
+
+        element_click_by_class_name(driver, 'btn-success')
+
+        # other elements might not be reachable immediately after click of "Save" button
+        WebDriverWait(driver, 30).until(
+            EC.presence_of_element_located((By.ID, 'start'))
+        )
+        assert "14" in element_get_attribute_by_xpath(driver, '//*[@id="start"]', 'value')
+
+        old_date = element_get_attribute_by_id(driver, 'start', 'value')
+        element_send_keys_by_id(driver, 'start', '99/99/9999')
+
+        element_click_by_id(driver, 'mFigs')
+
+        move_to_element_by_id(driver, 'start')
+        assert old_date in element_get_attribute_by_id(driver, 'start', 'value')
+
+        driver.find_element_by_id('start').send_keys('hello')
+        assert old_date in element_get_attribute_by_id(driver, 'start', 'value')
+
+        element_click_by_id(driver, 'mFigs')

--- a/test/frontend/test_conference_creation.py
+++ b/test/frontend/test_conference_creation.py
@@ -121,3 +121,36 @@ class TestConferenceCreation:
         assert old_date in element_get_attribute_by_id(driver, 'start', 'value')
 
         element_click_by_id(driver, 'mFigs')
+
+    def test_end_date(self):
+        driver = self.driver
+        WebDriverWait(driver, 30).until(
+            EC.presence_of_element_located((By.ID, 'end'))
+        )
+        element_click_by_id(driver, 'end')
+
+        move_to_element_by_id(driver, 'ui-datepicker-div')
+        driver.find_element_by_xpath('//a[contains(@class,"ui-datepicker-next")]').click()
+        driver.find_element_by_xpath('//div[@id="ui-datepicker-div"]//a[contains(text(), "16")]').click()
+        driver.find_element_by_xpath('//button[contains(@class, "datepicker-close")]').click()
+
+        element_click_by_class_name(driver, 'btn-success')
+
+        # other elements might not be reachable immediately after click of "Save" button
+        WebDriverWait(driver, 30).until(
+            EC.presence_of_element_located((By.ID, 'end'))
+        )
+        assert "16" in element_get_attribute_by_xpath(driver, '//*[@id="end"]', 'value')
+
+        old_date = element_get_attribute_by_id(driver, 'end', 'value')
+        element_send_keys_by_id(driver, 'end', '99/99/9999')
+
+        element_click_by_id(driver, 'mFigs')
+
+        move_to_element_by_id(driver, 'end')
+        assert old_date in element_get_attribute_by_id(driver, 'end', 'value')
+
+        driver.find_element_by_id('end').send_keys('hello')
+        assert old_date in element_get_attribute_by_id(driver, 'end', 'value')
+
+        element_click_by_id(driver, 'mFigs')

--- a/test/frontend/test_conference_creation.py
+++ b/test/frontend/test_conference_creation.py
@@ -420,6 +420,30 @@ class TestConferenceCreation:
         assert len(driver.find_elements_by_xpath('//ul/li/span[contains(text(),"Topic 1")]')) == 0
         assert len(driver.find_elements_by_xpath('//ul/li/span[contains(text(),"Topic 2")]')) == 1
 
+        tc_num = element_get_attribute_by_id(driver, 'short', 'value')
+        element_click_by_class_name(driver, 'btn-success')
+
+        driver.get("http://" + Cookies.get_host_ip() + ":9000/conference/" + tc_num + "/submission")
+
+        move_to_element_by_class_name(driver, 'topic')
+        WebDriverWait(driver, 10).until(
+            EC.visibility_of_element_located((By.ID, 'button-edit-topic'))
+        )
+        driver.find_element_by_id('button-edit-topic').click()
+
+        WebDriverWait(driver, 10).until(
+            EC.element_to_be_clickable((By.XPATH, '//*[@id="topic-editor"]//div[contains(@class, "radio")]'))
+        )
+
+        assert len(driver.find_elements_by_xpath('//*[@id="topic-editor"]//div[contains(@class, "radio")]//input')) == 1
+        assert "Topic 2" in driver.find_element_by_xpath('//*[@id="topic-editor"]'
+                                                         '//div[contains(@class, "radio")]//span').text
+
+        driver.find_element_by_xpath('//*[@id="topic-editor"]//button[@id="modal-button-ok"]').click()
+
+        driver.get("http://" + Cookies.get_host_ip() + ":9000/conference/" + tc_num)
+        element_click_by_xpath(driver, '//div[@class="jumbotron"]//a[contains(text(),"Conference Settings")]')
+
     def test_maximum_abstract_length(self):
         driver = self.driver
         WebDriverWait(driver, 30).until(

--- a/test/frontend/test_conference_creation.py
+++ b/test/frontend/test_conference_creation.py
@@ -282,6 +282,19 @@ class TestConferenceCreation:
         )
         element_send_keys_by_id(driver, 'logo', 'https://portal.g-node.org/abstracts/bc18/BC18_header.jpg')
 
+        tc_num = element_get_attribute_by_id(driver, 'short', 'value')
+        element_click_by_class_name(driver, 'btn-success')
+
+        driver.get("http://" + Cookies.get_host_ip() + ":9000/")
+
+        move_to_element_by_xpath(driver, '//div[@class="jumbotron"]/h3/a[contains(@href,"' + tc_num + '")]/../..')
+        conf_div = driver.find_element_by_xpath('//div[@class="jumbotron"]/h3'
+                                                '/a[contains(@href,"' + tc_num + '")]/../..')
+        assert len(conf_div.find_elements_by_xpath('.//p[contains(@data-bind,"logo")]//img[@src='
+                                                   '"https://portal.g-node.org/abstracts/bc18/BC18_header.jpg"]')) == 1
+
+        conf_div.find_element_by_xpath('.//a[contains(text(),"Conference Settings")]').click()
+
     def test_iosapp(self):
         driver = self.driver
         WebDriverWait(driver, 30).until(

--- a/test/frontend/test_conference_creation.py
+++ b/test/frontend/test_conference_creation.py
@@ -87,6 +87,15 @@ class TestConferenceCreation:
         tc_num = element_get_attribute_by_id(driver, 'short', 'value')
         element_click_by_class_name(driver, 'btn-success')
 
+        driver.get("http://" + Cookies.get_host_ip() + ":9000/")
+
+        conf_div = driver.find_element_by_xpath('//div[@class="media-body"]/a[contains(@href,"' + tc_num + '")]/..')
+
+        assert len(conf_div.find_elements_by_xpath('..//div[contains(@class,"media-left")]//a/img[@src='
+                                                   '"https://portal.g-node.org/abstracts/bc14/BC14_icon.png"]')) == 1
+
+        conf_div.find_element_by_xpath('.//a[contains(text(),"Conference Settings")]').click()
+
     def test_active(self):
         driver = self.driver
         WebDriverWait(driver, 30).until(

--- a/test/frontend/test_conference_creation.py
+++ b/test/frontend/test_conference_creation.py
@@ -191,3 +191,10 @@ class TestConferenceCreation:
             EC.presence_of_element_located((By.ID, 'logo'))
         )
         element_send_keys_by_id(driver, 'logo', 'https://portal.g-node.org/abstracts/bc18/BC18_header.jpg')
+
+    def test_iosapp(self):
+        driver = self.driver
+        WebDriverWait(driver, 30).until(
+            EC.presence_of_element_located((By.ID, 'iosapp'))
+        )
+        element_send_keys_by_id(driver, 'iosapp', '999999999')

--- a/test/frontend/test_conference_creation.py
+++ b/test/frontend/test_conference_creation.py
@@ -184,3 +184,10 @@ class TestConferenceCreation:
         element_click_by_id(driver, "mFigs")
         assert old_date in element_get_attribute_by_id(driver, 'deadline', 'value')
         element_click_by_id(driver, "mFigs")
+
+    def test_logo_url(self):
+        driver = self.driver
+        WebDriverWait(driver, 30).until(
+            EC.presence_of_element_located((By.ID, 'logo'))
+        )
+        element_send_keys_by_id(driver, 'logo', 'https://portal.g-node.org/abstracts/bc18/BC18_header.jpg')

--- a/test/frontend/test_conference_creation.py
+++ b/test/frontend/test_conference_creation.py
@@ -235,6 +235,15 @@ class TestConferenceCreation:
         assert old_date in element_get_attribute_by_id(driver, 'end', 'value')
 
         element_click_by_id(driver, 'mFigs')
+        tc_num = element_get_attribute_by_id(driver, 'short', 'value')
+
+        driver.get("http://" + Cookies.get_host_ip() + ":9000/")
+
+        move_to_element_by_xpath(driver, '//div[@class="jumbotron"]/h3/a[contains(@href,"' + tc_num + '")]/../..')
+        conf_div = driver.find_element_by_xpath('//div[@class="jumbotron"]/h3/a[contains(@href,"' + tc_num + '")]/../..')
+        assert len(conf_div.find_elements_by_xpath('./p[contains(text(),"16")]')) == 1
+
+        conf_div.find_element_by_xpath('.//a[contains(text(),"Conference Settings")]').click()
 
     def test_deadline(self):
         driver = self.driver

--- a/test/frontend/test_conference_creation.py
+++ b/test/frontend/test_conference_creation.py
@@ -82,3 +82,9 @@ class TestConferenceCreation:
             EC.presence_of_element_located((By.ID, 'group'))
         )
         element_send_keys_by_id(driver, 'group', 'Test Group 1')
+
+    def test_cite(self):
+        driver = self.driver
+        element_send_keys_by_id(driver, 'cite', 'The Test Conf, Somewhere, Sometime')
+
+        element_click_by_class_name(driver, 'btn-success')

--- a/test/frontend/test_conference_creation.py
+++ b/test/frontend/test_conference_creation.py
@@ -343,6 +343,15 @@ class TestConferenceCreation:
         )
         element_send_keys_by_id(driver, 'notice', 'Check abstracts before submission!')
 
+        tc_num = element_get_attribute_by_id(driver, 'short', 'value')
+        element_click_by_class_name(driver, 'btn-success')
+
+        driver.get("http://" + Cookies.get_host_ip() + ":9000/conference/" + tc_num)
+        assert len(driver.find_elements_by_xpath('//div[@class="jumbotron"]'
+                                                 '//p[contains(text(),"Check abstracts before submission!")]')) == 1
+
+        element_click_by_xpath(driver, '//div[@class="jumbotron"]//a[contains(text(),"Conference Settings")]')
+
     def test_presentation_preferences(self):
         driver = self.driver
         WebDriverWait(driver, 30).until(

--- a/test/frontend/test_conference_creation.py
+++ b/test/frontend/test_conference_creation.py
@@ -48,3 +48,14 @@ class TestConferenceCreation:
             EC.presence_of_element_located((By.ID, 'published'))
         )
         element_click_by_id(driver, 'published')
+
+    # thumbnail only shown if conference not active
+    def test_thumbnail_url(self):
+        driver = self.driver
+        WebDriverWait(driver, 30).until(
+            EC.presence_of_element_located((By.ID, 'thumbnail'))
+        )
+        element_send_keys_by_id(driver, 'thumbnail', 'https://portal.g-node.org/abstracts/bc14/BC14_icon.png')
+
+        tc_num = element_get_attribute_by_id(driver, 'short', 'value')
+        element_click_by_class_name(driver, 'btn-success')

--- a/test/frontend/test_conference_creation.py
+++ b/test/frontend/test_conference_creation.py
@@ -324,6 +324,18 @@ class TestConferenceCreation:
         )
         element_send_keys_by_id(driver, 'desc', 'Important conference.')
 
+        tc_num = element_get_attribute_by_id(driver, 'short', 'value')
+        element_click_by_class_name(driver, 'btn-success')
+
+        driver.get("http://" + Cookies.get_host_ip() + ":9000/conference/" + tc_num)
+
+        move_to_element_by_xpath(driver, '//div[@class="jumbotron"]'
+                                         '/div[@class="jumbo-small"]/p[@class="paragraph-small"]')
+        assert "Important conference." in driver.find_element_by_xpath(
+            '//div[@class="jumbotron"]/div[@class="jumbo-small"]/p[@class="paragraph-small"]').text
+
+        element_click_by_xpath(driver, '//div[@class="jumbotron"]//a[contains(text(),"Conference Settings")]')
+
     def test_notice(self):
         driver = self.driver
         WebDriverWait(driver, 30).until(

--- a/test/frontend/test_conference_creation.py
+++ b/test/frontend/test_conference_creation.py
@@ -306,6 +306,17 @@ class TestConferenceCreation:
         driver = self.driver
         element_send_keys_by_id(driver, 'link', 'http://www.nncn.de/en/bernstein-conference/2014')
 
+        tc_num = element_get_attribute_by_id(driver, 'short', 'value')
+        element_click_by_class_name(driver, 'btn-success')
+
+        driver.get("http://" + Cookies.get_host_ip() + ":9000/conference/" + tc_num)
+
+        assert len(driver.find_elements_by_xpath(
+            '//div[@class="jumbotron"]/div[contains(@data-bind,"logo")]'
+            '/a[contains(@href,"http://www.nncn.de/en/bernstein-conference/2014")]')) == 1
+
+        element_click_by_xpath(driver, '//div[@class="jumbotron"]//a[contains(text(),"Conference Settings")]')
+
     def test_description(self):
         driver = self.driver
         WebDriverWait(driver, 30).until(

--- a/test/frontend/test_conference_creation.py
+++ b/test/frontend/test_conference_creation.py
@@ -250,3 +250,23 @@ class TestConferenceCreation:
 
         assert len(driver.find_elements_by_xpath('//ul/li/span[contains(text(),"Topic 1")]')) == 0
         assert len(driver.find_elements_by_xpath('//ul/li/span[contains(text(),"Topic 2")]')) == 1
+
+    def test_maximum_abstract_length(self):
+        driver = self.driver
+        WebDriverWait(driver, 30).until(
+            EC.presence_of_element_located((By.ID, 'mAbsLen'))
+        )
+        # initial mAbsLen = 2000
+        element_send_keys_by_id(driver, 'mAbsLen', '300')
+
+        assert "Changing to shorter abstract length causes cut-offs" in \
+               driver.find_element_by_xpath('//div[contains(@class,"form-group")]'
+                                            '/div[contains(@class,"alert-danger")]').text
+
+        element_click_by_class_name(driver, 'btn-success')
+
+        WebDriverWait(driver, 30).until(
+            EC.presence_of_element_located((By.ID, 'mAbsLen'))
+        )
+        move_to_element_by_id(driver, 'mAbsLen')
+        assert "300" == driver.find_element_by_id('mAbsLen').get_attribute('value')

--- a/test/frontend/test_conference_creation.py
+++ b/test/frontend/test_conference_creation.py
@@ -75,3 +75,10 @@ class TestConferenceCreation:
         element_click_by_id(driver, 'submission')
 
         element_click_by_class_name(driver, 'btn-success')
+
+    def test_group(self):
+        driver = self.driver
+        WebDriverWait(driver, 30).until(
+            EC.presence_of_element_located((By.ID, 'group'))
+        )
+        element_send_keys_by_id(driver, 'group', 'Test Group 1')

--- a/test/frontend/test_conference_creation.py
+++ b/test/frontend/test_conference_creation.py
@@ -42,6 +42,19 @@ class TestConferenceCreation:
         )
         assert len(driver.find_elements_by_xpath('//div[contains(@class,"alert-danger")]/strong')) == 0
 
+        #move to front page and check, whether conference is shown and marked as "Unpublished"
+        driver.get("http://" + Cookies.get_host_ip() + ":9000/")
+
+        assert len(driver.find_elements_by_xpath('//div[@class="media-body"]/h4[@id="' + tc_num + '"]')) == 1
+
+        move_to_element_by_xpath(driver, '//div[@class="media-body"]/h4[@id="' + tc_num + '"]')
+        conf_div = driver.find_element_by_xpath('//div[@class="media-body"]/h4[@id="' + tc_num + '"]/..')
+        assert len(conf_div.find_elements_by_xpath('./h4[contains(text(),"Unpublished")]')) == 1
+        assert len(conf_div.find_elements_by_xpath('./h4[contains(text(),"Test Conference")]')) == 1
+
+        conf_div.find_element_by_xpath('.//a[contains(text(),"Conference Settings")]').click()
+
+
     def test_published(self):
         driver = self.driver
         WebDriverWait(driver, 30).until(

--- a/test/frontend/test_conference_creation.py
+++ b/test/frontend/test_conference_creation.py
@@ -238,3 +238,15 @@ class TestConferenceCreation:
         driver.find_element_by_id('btn-add-topic').click()
 
         assert len(driver.find_elements_by_xpath('//ul/li/span[contains(text(),"Topic 2")]')) == 1
+
+    def test_remove_topic(self):
+        driver = self.driver
+        WebDriverWait(driver, 30).until(
+            EC.presence_of_element_located((By.ID, 'addTopic'))
+        )
+
+        move_to_element_by_xpath(driver, '//ul/li/span[contains(text(),"Topic 1")]/../a')
+        driver.find_element_by_xpath('//ul/li/span[contains(text(),"Topic 1")]/../a').click()
+
+        assert len(driver.find_elements_by_xpath('//ul/li/span[contains(text(),"Topic 1")]')) == 0
+        assert len(driver.find_elements_by_xpath('//ul/li/span[contains(text(),"Topic 2")]')) == 1

--- a/test/frontend/test_conference_creation.py
+++ b/test/frontend/test_conference_creation.py
@@ -209,3 +209,10 @@ class TestConferenceCreation:
             EC.presence_of_element_located((By.ID, 'desc'))
         )
         element_send_keys_by_id(driver, 'desc', 'Important conference.')
+
+    def test_notice(self):
+        driver = self.driver
+        WebDriverWait(driver, 30).until(
+            EC.presence_of_element_located((By.ID, 'notice'))
+        )
+        element_send_keys_by_id(driver, 'notice', 'Check abstracts before submission!')

--- a/test/frontend/test_conference_creation.py
+++ b/test/frontend/test_conference_creation.py
@@ -4,7 +4,10 @@ from uuid import uuid1
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
-from conftest import *
+from conftest import element_send_keys_by_id, element_send_keys_by_class_name, element_send_keys_by_xpath, \
+    element_click_by_id, element_click_by_class_name, element_click_by_xpath, \
+    element_get_attribute_by_id, element_get_attribute_by_class_name, element_get_attribute_by_xpath, \
+    move_to_element_by_id, move_to_element_by_class_name, move_to_element_by_xpath
 
 
 @pytest.mark.usefixtures("setup_conference_creation")

--- a/test/frontend/test_conference_creation.py
+++ b/test/frontend/test_conference_creation.py
@@ -49,7 +49,7 @@ class TestConferenceCreation:
 
         move_to_element_by_xpath(driver, '//div[@class="media-body"]/h4[@id="' + tc_num + '"]')
         conf_div = driver.find_element_by_xpath('//div[@class="media-body"]/h4[@id="' + tc_num + '"]/..')
-        assert len(conf_div.find_elements_by_xpath('./h4[contains(text(),"Unpublished")]')) == 1
+        assert 'unpublished' in conf_div.find_element_by_xpath('..').get_attribute('class')
         assert len(conf_div.find_elements_by_xpath('./h4[contains(text(),"Test Conference")]')) == 1
 
         conf_div.find_element_by_xpath('.//a[contains(text(),"Conference Settings")]').click()
@@ -70,7 +70,7 @@ class TestConferenceCreation:
         assert len(driver.find_elements_by_xpath('//div[@class="media-body"]/a[contains(@href,"' + tc_num + '")]')) == 1
 
         conf_div = driver.find_element_by_xpath('//div[@class="media-body"]/a[contains(@href,"' + tc_num + '")]/..')
-        assert len(conf_div.find_elements_by_xpath('./h4')) == 0
+        assert 'unpublished' not in conf_div.find_element_by_xpath('..').get_attribute('class')
         assert len(conf_div.find_elements_by_xpath('.//a[contains(text(),"Manage")]')) == 1
         assert len(conf_div.find_elements_by_xpath('.//a[contains(text(),"Conference Settings")]')) == 1
 

--- a/test/frontend/test_conference_creation.py
+++ b/test/frontend/test_conference_creation.py
@@ -223,3 +223,18 @@ class TestConferenceCreation:
             EC.presence_of_element_located((By.ID, 'presentation'))
         )
         element_click_by_id(driver, 'presentation')
+
+    def test_add_topic(self):
+        driver = self.driver
+        WebDriverWait(driver, 30).until(
+            EC.presence_of_element_located((By.ID, 'addTopic'))
+        )
+        element_send_keys_by_id(driver, 'addTopic', 'Topic 1')
+        driver.find_element_by_id('btn-add-topic').click()
+
+        assert len(driver.find_elements_by_xpath('//ul/li/span[contains(text(),"Topic 1")]')) == 1
+
+        element_send_keys_by_id(driver, 'addTopic', 'Topic 2')
+        driver.find_element_by_id('btn-add-topic').click()
+
+        assert len(driver.find_elements_by_xpath('//ul/li/span[contains(text(),"Topic 2")]')) == 1

--- a/test/frontend/test_conference_creation.py
+++ b/test/frontend/test_conference_creation.py
@@ -62,6 +62,20 @@ class TestConferenceCreation:
         )
         element_click_by_id(driver, 'published')
 
+        tc_num = element_get_attribute_by_id(driver, 'short', 'value')
+        element_click_by_class_name(driver, 'btn-success')
+
+        driver.get("http://" + Cookies.get_host_ip() + ":9000/")
+
+        assert len(driver.find_elements_by_xpath('//div[@class="media-body"]/a[contains(@href,"' + tc_num + '")]')) == 1
+
+        conf_div = driver.find_element_by_xpath('//div[@class="media-body"]/a[contains(@href,"' + tc_num + '")]/..')
+        assert len(conf_div.find_elements_by_xpath('./h4')) == 0
+        assert len(conf_div.find_elements_by_xpath('.//a[contains(text(),"Manage")]')) == 1
+        assert len(conf_div.find_elements_by_xpath('.//a[contains(text(),"Conference Settings")]')) == 1
+
+        conf_div.find_element_by_xpath('.//a[contains(text(),"Conference Settings")]').click()
+
     # thumbnail only shown if conference not active
     def test_thumbnail_url(self):
         driver = self.driver

--- a/test/frontend/test_conference_creation.py
+++ b/test/frontend/test_conference_creation.py
@@ -202,3 +202,10 @@ class TestConferenceCreation:
     def test_link(self):
         driver = self.driver
         element_send_keys_by_id(driver, 'link', 'http://www.nncn.de/en/bernstein-conference/2014')
+
+    def test_description(self):
+        driver = self.driver
+        WebDriverWait(driver, 30).until(
+            EC.presence_of_element_located((By.ID, 'desc'))
+        )
+        element_send_keys_by_id(driver, 'desc', 'Important conference.')

--- a/test/frontend/test_conference_creation.py
+++ b/test/frontend/test_conference_creation.py
@@ -384,6 +384,30 @@ class TestConferenceCreation:
 
         assert len(driver.find_elements_by_xpath('//ul/li/span[contains(text(),"Topic 2")]')) == 1
 
+        tc_num = element_get_attribute_by_id(driver, 'short', 'value')
+
+        element_click_by_class_name(driver, 'btn-success')
+
+        driver.get("http://" + Cookies.get_host_ip() + ":9000/conference/" + tc_num + "/submission")
+
+        move_to_element_by_class_name(driver, 'topic')
+        WebDriverWait(driver, 10).until(
+            EC.visibility_of_element_located((By.ID, 'button-edit-topic'))
+        )
+        driver.find_element_by_id('button-edit-topic').click()
+
+        WebDriverWait(driver, 10).until(
+            EC.element_to_be_clickable((By.XPATH, '//*[@id="topic-editor"]//div[contains(@class, "radio")]'))
+        )
+
+        assert len(driver.find_elements_by_xpath('//*[@id="topic-editor"]//div[contains(@class, "radio")]//input')) == 2
+
+        driver.find_element_by_xpath('//*[@id="topic-editor"]//button[@id="modal-button-ok"]').click()
+
+        driver.get("http://" + Cookies.get_host_ip() + ":9000/conference/" + tc_num)
+
+        element_click_by_xpath(driver, '//div[@class="jumbotron"]//a[contains(text(),"Conference Settings")]')
+
     def test_remove_topic(self):
         driver = self.driver
         WebDriverWait(driver, 30).until(

--- a/test/frontend/test_conference_creation.py
+++ b/test/frontend/test_conference_creation.py
@@ -59,3 +59,10 @@ class TestConferenceCreation:
 
         tc_num = element_get_attribute_by_id(driver, 'short', 'value')
         element_click_by_class_name(driver, 'btn-success')
+
+    def test_active(self):
+        driver = self.driver
+        WebDriverWait(driver, 30).until(
+            EC.presence_of_element_located((By.ID, 'active'))
+        )
+        element_click_by_id(driver, 'active')

--- a/test/frontend/test_conference_creation.py
+++ b/test/frontend/test_conference_creation.py
@@ -19,3 +19,25 @@ class TestConferenceCreation:
         assert "TC" in element_get_attribute_by_id(driver, 'short', 'value')
         assert "500" == element_get_attribute_by_id(driver, 'mAbsLen', 'value')
         assert "0" == element_get_attribute_by_id(driver, 'mFigs', 'value')
+
+    def test_short(self):
+        driver = self.driver
+        tc_num = "TC" + str(uuid1())[0:8]
+        element_send_keys_by_id(driver, 'short', 'BC14')
+
+        element_click_by_class_name(driver, 'btn-success')
+
+        WebDriverWait(driver, 30).until(
+            EC.presence_of_element_located((By.XPATH, '//div[contains(@class,"alert-danger")]/strong'))
+        )
+        assert "Conference short is already in use." in \
+               driver.find_element_by_xpath('//div[contains(@class,"alert-danger")]/strong').text
+
+        element_send_keys_by_id(driver, 'short', tc_num)
+
+        element_click_by_class_name(driver, 'btn-success')
+
+        WebDriverWait(driver, 30).until(
+            EC.invisibility_of_element_located((By.XPATH, '//div[contains(@class,"alert-danger")]/strong'))
+        )
+        assert len(driver.find_elements_by_xpath('//div[contains(@class,"alert-danger")]/strong')) == 0

--- a/test/frontend/test_conference_creation.py
+++ b/test/frontend/test_conference_creation.py
@@ -193,6 +193,15 @@ class TestConferenceCreation:
         assert old_date in element_get_attribute_by_id(driver, 'start', 'value')
 
         element_click_by_id(driver, 'mFigs')
+        tc_num = element_get_attribute_by_id(driver, 'short', 'value')
+
+        driver.get("http://" + Cookies.get_host_ip() + ":9000/")
+
+        move_to_element_by_xpath(driver, '//div[@class="jumbotron"]/h3/a[contains(@href,"' + tc_num + '")]/../..')
+        conf_div = driver.find_element_by_xpath('//div[@class="jumbotron"]/h3/a[contains(@href,"' + tc_num + '")]/../..')
+        assert len(conf_div.find_elements_by_xpath('./p[contains(text(),"14")]')) == 1
+
+        conf_div.find_element_by_xpath('.//a[contains(text(),"Conference Settings")]').click()
 
     def test_end_date(self):
         driver = self.driver

--- a/test/frontend/test_conference_creation.py
+++ b/test/frontend/test_conference_creation.py
@@ -154,3 +154,33 @@ class TestConferenceCreation:
         assert old_date in element_get_attribute_by_id(driver, 'end', 'value')
 
         element_click_by_id(driver, 'mFigs')
+
+    def test_deadline(self):
+        driver = self.driver
+        WebDriverWait(driver, 30).until(
+            EC.presence_of_element_located((By.ID, 'deadline'))
+        )
+        element_click_by_id(driver, 'deadline')
+        driver.find_element_by_id('deadline').click()
+
+        move_to_element_by_id(driver, 'ui-datepicker-div')
+        driver.find_element_by_xpath('//a[contains(@class,"ui-datepicker-next")]').click()
+        driver.find_element_by_xpath('//div[@id="ui-datepicker-div"]//a[contains(text(), "10")]').click()
+        driver.find_element_by_xpath('//button[contains(@class, "datepicker-close")]').click()
+
+        element_click_by_class_name(driver, 'btn-success')
+
+        WebDriverWait(driver, 30).until(
+            EC.presence_of_element_located((By.ID, 'deadline'))
+        )
+        assert "10" in element_get_attribute_by_xpath(driver, '//*[@id="deadline"]', 'value')
+
+        old_date = element_get_attribute_by_id(driver, 'deadline', 'value')
+        element_send_keys_by_id(driver, 'deadline', '99/99/9999')
+        element_click_by_id(driver, "mFigs")
+
+        assert old_date in element_get_attribute_by_id(driver, 'deadline', 'value')
+        driver.find_element_by_id('deadline').send_keys('hello')
+        element_click_by_id(driver, "mFigs")
+        assert old_date in element_get_attribute_by_id(driver, 'deadline', 'value')
+        element_click_by_id(driver, "mFigs")


### PR DESCRIPTION
This PR
- Introduces functions for frontend tests that include scrolling for Firefox for click(), send_keys() and get_attribute()
- Adds conference creation tests for all fields that don't require uploading.
- Includes frontend look-ups to check, whether the filling in of the conference settings form works correctly and changes are shown in the non-admin frontend.
- Adds unpublished, non-active conferences to the admins conference list, marked by an "Unpublished"-tag. Closes #500 
- Adds some remarks about writing tests to the selenium-tests read.me
- Removes the selenium jar, as users should download the newest version for themselves
- Replaces the cookies.json with direct admin login for frontend tests