### PR TITLE
Fixes and updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ until the next release.
 
 # Release v1.3
 
+## Database changes
 This release contains required database changes. After redeployment the database needs to be updated manually using script `patch/patch_v1_2_to_v1_3.sql` and the database service restarted for the changes to take effect.
+
+## Build issues
+The current project setup is still using an outdated build tool (`activator`) and is several versions behind the current state of the play framework. The default sbt CDNs for the underlying build dependencies have been updated and no longer provide the required dependencies. Therefore additional CDNs have been added to the project build to keep it in a buildable state. The docker build has been changed to a layered build to decrease build times. See issue #497 and PRs #498 and #509 for details.
 
 ## Features
 - Stars will be shown in the conference abstract list, indicating favourite abstracts of a user. For details see issue #419.
@@ -14,8 +18,10 @@ This release contains required database changes. After redeployment the database
 - Mobile versions of Figures and conference banners are now automatically created when a figure or banner is uploaded.
 - Both site and conference admins are now able to upload banners via the conference administration.
 - The selenium framework is introduced to integrate frontend tests.
-- The way DOI is represented in the abstract submission for has been updated. For details see issue #478.
+- The way a DOI is represented in the abstract submission form has been updated. For details see issue #478.
 - A conference dependent notice can now be added via the conference administration page. The text will be displayed for the respective conference only. This change requires a database change. After deployment of this version, the database needs to be updated manually using script `patch/patch_v1_2_to_v1_3.sql`. For details see issue #470.
+- A search field has been added to the abstract list of a conference. For details see PR #505.
+- Print view specific stylesheets were added for useful print rendering of abstract pages. See issue #508 for details.
 
 ## Fixes
 - The string length of notes when changing abstract states will be limited to 255 to avoid database problems. For details see issue #448.
@@ -25,6 +31,9 @@ This release contains required database changes. After redeployment the database
 - Added feedback on a failed email change attempt. For details see issue #467.
 - Added sign-up notification after new user registration. For details see issue #473.
 - The login status is now always properly displayed. For details see issue #468.
+- Added error messages on abstract reference validation, if the input is numeric. For details see issue #499.
+- The outdated mapbox.js plugin was updated to the latest version. See issue #510 for details.
+- An issue was resolved where the sortid of an abstract was removed when an abstract was re-submitted. See issue #507 for details.
 
 
 # Release v1.2

--- a/app/assets/javascripts/lib/models.js
+++ b/app/assets/javascripts/lib/models.js
@@ -1093,6 +1093,7 @@ define(["lib/tools", "lib/accessors",  "moment", "knockout"], function(tools, ac
 
         var self = tools.inherit(this, Model, uuid);
 
+        self.sortId = sortId || 0;
         self.title = ko.observable(title || null);
         self.topic = ko.observable(topic || null);
         self.text = ko.observable(text || null);

--- a/app/assets/javascripts/locations.js
+++ b/app/assets/javascripts/locations.js
@@ -43,12 +43,16 @@ require(["lib/models", "lib/tools", "lib/leaflet/leaflet", "lib/msg", "lib/astat
                     if (self.mapType === "locations") {
                         $("#map-div").height(0.75 * $("#map-div").width());
                         var confmap = L.map("map-div");
-                        L.tileLayer("https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token={accessToken}", {
-                            attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, <a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery © <a href="https://www.mapbox.com/">Mapbox</a>',
+
+                        L.tileLayer('https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}?access_token={accessToken}', {
+                            attribution: '© <a href="https://www.mapbox.com/about/maps/">Mapbox</a> © <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> <strong><a href="https://www.mapbox.com/map-feedback/" target="_blank">Improve this map</a></strong>',
+                            tileSize: 512,
                             maxZoom: 20,
-                            id: "mapbox.streets",
+                            zoomOffset: -1,
+                            id: 'mapbox/streets-v11',
                             accessToken: "pk.eyJ1IjoiZ25vZGUiLCJhIjoiY2prOGFnbzY2MWlmNzN3bzRhY205N2oxZCJ9.-j7b1aziK9nUNjgHQh0ojw"
                         }).addTo(confmap);
+
                         var texts = "";
 
                         for (var i = 0; i < geojson.length; i++) {

--- a/app/assets/stylesheets/custom/bootstrap/_custom-print.less
+++ b/app/assets/stylesheets/custom/bootstrap/_custom-print.less
@@ -7,3 +7,57 @@
 .navbar, .footer, .hidden-data, .nav, .jumbo-small, .callout, .pager, .alert {
   display: none;
 }
+
+// Display the conference name but do not display the local link in the print view
+.page-header {
+  h1 {
+    a[href]:after {
+      display: none;
+    }
+  }
+}
+
+.affiliations, .abstract-text, .acknowledgements, .references {
+  margin: 0.5em;
+  padding: 0.5em;
+}
+
+// Required to properly display abstract authors in the print view
+.authors {
+  padding: 0;
+  margin: 0;
+  margin-top: 0.2em;
+  list-style: none;
+  display: inline-block;
+  font-size: 14px;
+
+  ul {
+    padding: 0;
+    margin: 0;
+    list-style: none;
+    display: inline-block;
+    font-size: large;
+  }
+
+  li {
+    display: inline-block;
+
+    span:after {
+      content: " ";
+    }
+  }
+
+  li:after {
+    content: ", ";
+  }
+
+  li:last-child:after {
+    content: "" !important;
+  }
+}
+
+// Required to properly display abstract copyright text in the print view
+.foot-info ul {
+  list-style-type: none;
+  padding-left: 0px;
+}

--- a/app/assets/stylesheets/custom/bootstrap/_custom-print.less
+++ b/app/assets/stylesheets/custom/bootstrap/_custom-print.less
@@ -1,0 +1,9 @@
+// Do not display elements with the class noprint in the print view
+.noprint {
+  display: none;
+}
+
+// Do not display specific elements in the print view
+.navbar, .footer, .hidden-data, .nav, .jumbo-small, .callout, .pager, .alert {
+  display: none;
+}

--- a/app/assets/stylesheets/g-node-bootstrap-print.play.less
+++ b/app/assets/stylesheets/g-node-bootstrap-print.play.less
@@ -1,0 +1,68 @@
+// file used for compilation within a play framework
+
+// adjust this to the path where the original bootstrap less files are located
+@bootPath: "/lib/bootstrap/less/";
+// adjust this to the path where the custom less files are located
+@customPath: "custom/bootstrap/";
+
+// Core variables and mixins
+@import "@{bootPath}variables";
+@import "@{bootPath}mixins";
+
+// Custom variables, overwrite existing bootstrap variables
+@import "@{customPath}_custom-colors";
+@import "@{customPath}_custom-vars";
+
+// Reset
+@import "@{bootPath}normalize";
+@import "@{bootPath}print";
+
+// Core CSS
+@import "@{bootPath}scaffolding";
+@import "@{bootPath}type";
+@import "@{bootPath}code";
+@import "@{bootPath}grid";
+@import "@{bootPath}tables";
+@import "@{bootPath}forms";
+@import "@{bootPath}buttons";
+
+// Components
+@import "@{bootPath}component-animations";
+@import "@{bootPath}glyphicons";
+@import "@{bootPath}dropdowns";
+@import "@{bootPath}button-groups";
+@import "@{bootPath}input-groups";
+@import "@{bootPath}navs";
+@import "@{bootPath}navbar";
+@import "@{bootPath}breadcrumbs";
+@import "@{bootPath}pagination";
+@import "@{bootPath}pager";
+@import "@{bootPath}labels";
+@import "@{bootPath}badges";
+@import "@{bootPath}jumbotron";
+@import "@{bootPath}thumbnails";
+@import "@{bootPath}alerts";
+@import "@{bootPath}progress-bars";
+@import "@{bootPath}media";
+@import "@{bootPath}list-group";
+@import "@{bootPath}panels";
+@import "@{bootPath}wells";
+@import "@{bootPath}close";
+
+// Components w/ JavaScript
+@import "@{bootPath}modals";
+@import "@{bootPath}tooltip";
+@import "@{bootPath}popovers";
+@import "@{bootPath}carousel";
+
+// Utility classes
+@import "@{bootPath}utilities";
+@import "@{bootPath}responsive-utilities";
+
+// Custom elements
+@import "@{customPath}_custom-elements";
+
+// Custom print view elements; needs to be the last import
+// to make sure existing styles are overwritten by the print
+// style.
+@import "@{customPath}_custom-print";

--- a/app/views/conferencelist.scala.html
+++ b/app/views/conferencelist.scala.html
@@ -99,10 +99,13 @@
         }
 
         @if(account.isDefined) {
-            <hr>
-                <h3>Unpublished conferences</h3>
-            <br/>
             @for((conference,i) <- list_other.zipWithIndex) {
+                @if(i == 0 && (conference.isOwner(account.get) || account.get.isAdmin)) {
+                    <hr>
+                    <h3>Unpublished conferences</h3>
+                    <br/>
+                }
+
                 @if(!conference.isPublished && (conference.isOwner(account.get) || account.get.isAdmin)) {
                     <div class="media unpublished">
                         <div class="pull-left media-left">

--- a/app/views/conferencelist.scala.html
+++ b/app/views/conferencelist.scala.html
@@ -67,7 +67,7 @@
                         <a href="@routes.Application.conference(conference.short)"
                         data-bind="ifnot: $root.thumbnails()[@i]">
                         @if(conference.getConfText("thumbnail") != null && conference.getConfText("thumbnail") != "") {
-                            <img class="conference-logo img-responsive img-rounded"
+                            <img class="media-object conference-thumbnail"
                             src='@conference.getConfText("thumbnail")'>
                         }
                         </a>

--- a/app/views/template.scala.html
+++ b/app/views/template.scala.html
@@ -31,6 +31,10 @@
     <link rel="stylesheet" href='@routes.Assets.at("lib/jquery-ui/jquery-ui.min.css")' />
     <script type="text/javascript" src='@routes.Assets.at("lib/bootstrap/js/bootstrap.min.js")'></script>
 
+    <!-- Print view specific stylesheet -->
+    <link rel="stylesheet" type="text/css" media="print"
+          href='@routes.Assets.at("stylesheets/g-node-bootstrap-print.play.css")' />
+
     <!-- project fonts -->
     <link href='//fonts.googleapis.com/css?family=EB+Garamond|Open+Sans' rel='stylesheet' type='text/css'>
 

--- a/doc/json_examples/locations.json
+++ b/doc/json_examples/locations.json
@@ -1,0 +1,38 @@
+[
+  {
+    "ExtendedData":"",
+    "name":"Event A",
+    "description":"Theologicum, Liebermeisterstrasse 12, 72076 Tuebingen",
+    "point":
+    {
+      "lat":48.525742885891795,
+      "long":9.055126905441284
+    },
+    "type":0,
+    "zoomto":true
+  },
+  {
+    "ExtendedData":"",
+    "name":"Event B",
+    "description":"Neckarmueller, Gartenstrasse , 72076 Tuebingen",
+    "point":
+    {
+      "lat":48.51933329151785,
+      "long":9.058645963668823
+    },
+    "type":5,
+    "zoomto":true
+  },
+  {
+    "ExtendedData":"",
+    "name":"Event C",
+    "description":"Rittersaal, Burgsteige 11, 72076 Tuebingen",
+    "point":
+    {
+      "lat":48.51937237686814,
+      "long":9.050610065460205
+    },
+    "type":0,
+    "zoomto":true
+  }
+]

--- a/doc/json_examples/schedule.json
+++ b/doc/json_examples/schedule.json
@@ -1,0 +1,161 @@
+[
+  {
+    "title": "Satellite Workshops",
+    "subtitle": "Description",
+    "tracks": [
+      {
+        "title": "Session title",
+        "subtitle": null,
+        "chair": ["Chair name"],
+        "events": [
+          {
+            "title": "Session Day I",
+            "subtitle": null,
+            "start": "14:00",
+            "end": "18:30",
+            "date": "2018-09-25",
+            "location": "Some Address",
+            "type": "workshop",
+            "authors": ["Author A", "Author B"]
+          },
+          {
+            "title": "Session Day II",
+            "subtitle": null,
+            "start": "08:30",
+            "end": "12:30",
+            "date": "2018-09-26",
+            "location": "Other Address",
+            "type": "workshop",
+            "authors": ["Author A", "Author B"]
+          }
+        ]
+      },
+      {
+        "title": "Other Session title",
+        "subtitle": null,
+        "chair": ["Chair A","Chair B"],
+        "events": [
+          {
+            "title": "Session Day I",
+            "subtitle": null,
+            "start": "14:00",
+            "end": "18:30",
+            "date": "2018-09-25",
+            "location": "Address 1",
+            "type": "workshop",
+            "authors": ["Author A"]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "title": "Postdoc Meeting",
+    "subtitle": null,
+    "start": "19:00",
+    "end": null,
+    "location": "Some address",
+    "date": "2018-09-25",
+    "authors": [],
+    "type": "social",
+    "abstract": null
+  },
+  {
+    "title" : "Conference Opening",
+    "subtitle" : null,
+    "chair" : [],
+    "events" : [
+      {
+        "title": "Welcome by Name A",
+        "subtitle": "President of the Technische Universität",
+        "start": "14:00",
+        "end": "14:05",
+        "location": null,
+        "date": "2018-09-26",
+        "authors": ["Author A"],
+        "type": "talk",
+        "abstract": null
+      },
+      {
+        "title": "Opening Lecture",
+        "subtitle": "Pushing the limits",
+        "start": "14:15",
+        "end": "15:00",
+        "location": null,
+        "date": "2018-09-26",
+        "authors": ["Author A"],
+        "type": "talk",
+        "abstract": null
+      }
+    ]
+  },
+  {
+    "title" : "Braitenberg Award",
+    "subtitle" : null,
+    "chair" : [],
+    "events" : [
+      {
+        "title": "Valentino Braitenberg Award Ceremony",
+        "subtitle": null,
+        "start": "15:00",
+        "end": "15:20",
+        "location": null,
+        "date": "2018-09-26",
+        "authors": [],
+        "type": "symposium",
+        "abstract": null
+      }
+    ]
+  },
+  {
+    "title": "Poster Session I",
+    "subtitle": null,
+    "start": "16:00",
+    "end": "19:30",
+    "location": null,
+    "date": "2018-09-26",
+    "authors": [],
+    "type": "poster",
+    "abstract": null
+  },
+  {
+    "title": "Coffee Break",
+    "subtitle": null,
+    "start": "10:30",
+    "end": "11:00",
+    "location": null,
+    "date": "2018-09-27",
+    "authors": [],
+    "type": "break",
+    "abstract": null
+  },
+  {
+    "title" : "Session II",
+    "subtitle" : null,
+    "chair" : [],
+    "events" : [
+      {
+        "title": "Some title",
+        "subtitle": null,
+        "start": "11:00",
+        "end": "11:45",
+        "location": null,
+        "date": "2018-09-27",
+        "authors": ["Author A"],
+        "type": "talk",
+        "abstract": null
+      },
+      {
+        "title": "Other title",
+        "subtitle": null,
+        "start": "11:45",
+        "end": "12:30",
+        "location": null,
+        "date": "2018-09-27",
+        "authors": ["Author B"],
+        "type": "talk",
+        "abstract": null
+      }
+    ]
+  }
+]

--- a/patch/patch_v1_2_to_v1_3.sql
+++ b/patch/patch_v1_2_to_v1_3.sql
@@ -2,6 +2,9 @@
 SQL script to copy the content of 'description', 'logo' URL and 'thumbnail' URL
 from the 'conference' table to the new 'conftext' table. The columns above will be deprecated.
 This script is required when migrating from GCA-Web v1.2 to v1.3.
+
+Make sure uuid_generate_v1 is available by enabling the extension uuid-ossp as
+the postgres superuser in database play: 'CREATE EXTENSION IF NOT EXISTS "uuid-ossp";'
 */
 
 INSERT INTO conftext (uuid, cttype, "text", conference_uuid)


### PR DESCRIPTION
This PR adds a couple of fixes and updates:
- print view specific stylesheets are added for useful print rendering of abstract pages. Closes #508.
- an issue was resolved where thumbnails on the main page where not properly scaled.
- an issue was resolved where the "unlisted conferences" title was displayed to non-admin users. Closes #500.
- the mapbox.js plugin was outdated, this PR updates it to the latest version. Closes #510.
- an issue was resolved where the sortid of an abstract was removed when an abstract was re-submitted. Closes issue #507.